### PR TITLE
UI/ux

### DIFF
--- a/src/components/currency-value-display.tsx
+++ b/src/components/currency-value-display.tsx
@@ -78,8 +78,9 @@ export default function CurrencyValueDisplay({
           onClick?.(display);
         }}
       >
-        <div>{display}</div>
-        <Image src={icon} alt={""} width={24} height={24} />
+        <div className="flex flex-row min-w-[50px]">{display}</div>
+
+        <Image src={icon} alt={""} width={30} height={30} />
       </div>
     </>
   );

--- a/src/components/filterable-item-table.tsx
+++ b/src/components/filterable-item-table.tsx
@@ -274,7 +274,7 @@ export default function FilterableItemTable({
         <div>
           <table className="table-auto w-full">
             <thead>
-              <tr className="w-full">
+              <tr className="w-full text-left">
                 <th></th>
                 <th></th>
                 <th>Name</th>
@@ -317,11 +317,11 @@ export default function FilterableItemTable({
             <tbody className="h-80">
               {itemGroupSearchResult.itemGroupSummaries!.map(
                 (summary, index) => (
-                  <tr key={index}>
+                  <tr key={index} className="text-left">
                     <td>
                       <input
                         type="checkbox"
-                        className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded"
+                        className="peer w-4 h-4 text-content-accent bg-gray-100 border-gray-300 rounded "
                         checked={
                           !excludedItemGroupHashStrings.includes(
                             summary?.itemGroup?.hashString!
@@ -364,9 +364,10 @@ export default function FilterableItemTable({
                         />
                       </Link>
                     </td>
-                    <td>
+                    <td className="">
                       <Link
                         href={`/poe/economy/${snapshot.league}/item-group/${summary.itemGroup?.hashString}`}
+                        className="hover:text-content-accent peer-checked:text-content-accent"
                       >
                         {GeneralUtils.itemGroupToDisplayName(
                           summary?.itemGroup
@@ -374,7 +375,7 @@ export default function FilterableItemTable({
                       </Link>
                     </td>
                     <td>
-                      <StyledPopover text={"Econ"}>
+                      <StyledPopover text={"Show Econ"}>
                         <QuantityChart
                           timeseries={
                             itemValueTimeseries?.find(
@@ -405,7 +406,7 @@ export default function FilterableItemTable({
                                 summary.itemGroup!.hashString
                               ] ?? null
                             }
-                            className="bg-transparent border border-theme-color-2 focus:border-theme-color-2 rounded-lg"
+                            className="bg-transparent border border-color-primary focus:border-color-primary rounded-lg"
                             placeholder={"" + summary?.valueChaos}
                             required
                             onChange={(e) => {

--- a/src/components/snapshot-table.tsx
+++ b/src/components/snapshot-table.tsx
@@ -55,7 +55,7 @@ export default function SnapshotTable({
           />
         </div>
         <div className="h-64 overflow-y-auto">
-          <table className="table-auto w-full">
+          <table className="table-auto w-full text-left">
             <thead>
               <tr>
                 <th></th>

--- a/src/components/sortable-table-header.tsx
+++ b/src/components/sortable-table-header.tsx
@@ -73,18 +73,16 @@ export default function SortableTableHeader({
     <thead>
       <tr>
         {columns.map((column) => (
-          <th className="pl-4 " key={column.key}>
+          <th className="pl-2" key={column.key}>
             <button
-              className="flex flex-row  w-full"
+              className="flex flex-row w-full"
               onClick={(e) => {
                 onColumnHeaderClick(column.key);
               }}
               disabled={column.notSortable}
             >
-              <div className="w-full flex justify-center  ">
-                {column.text}
-                <OrderIndicatorIcon direction={columnDirections[column.key]} />
-              </div>
+              {column.text}
+              <OrderIndicatorIcon direction={columnDirections[column.key]} />
             </button>
           </th>
         ))}

--- a/src/components/sortable-table-header.tsx
+++ b/src/components/sortable-table-header.tsx
@@ -70,19 +70,21 @@ export default function SortableTableHeader({
   }
 
   return (
-    <thead className="text-left">
+    <thead>
       <tr>
         {columns.map((column) => (
-          <th className="pl-2" key={column.key}>
+          <th className="pl-4 " key={column.key}>
             <button
-              className="flex flex-row"
+              className="flex flex-row  w-full"
               onClick={(e) => {
                 onColumnHeaderClick(column.key);
               }}
               disabled={column.notSortable}
             >
-              {column.text}
-              <OrderIndicatorIcon direction={columnDirections[column.key]} />
+              <div className="w-full flex justify-center  ">
+                {column.text}
+                <OrderIndicatorIcon direction={columnDirections[column.key]} />
+              </div>
             </button>
           </th>
         ))}

--- a/src/pages/poe/economy/[league].tsx
+++ b/src/pages/poe/economy/[league].tsx
@@ -183,10 +183,10 @@ export default function Economy() {
                         )}
                       </Link>
                     </td>
-                    <td className="flex flex-col items-center">
+                    <td className="flex flex-col items-start">
                       <HSparkline data={groupSeries.series} />
                     </td>
-                    <td className="text-center">
+                    <td className="text-left">
                       {(() => {
                         const recent = groupSeries.series?.find(
                           (s) => s.type === "totalValidListings"
@@ -202,7 +202,7 @@ export default function Economy() {
                         );
                       })()}
                     </td>
-                    <td className="flex flex-col items-center">
+                    <td className="flex flex-col">
                       {(() => {
                         const recent = groupSeries.series?.find(
                           (s) => s.type === "p10"

--- a/src/pages/poe/economy/[league].tsx
+++ b/src/pages/poe/economy/[league].tsx
@@ -158,6 +158,7 @@ export default function Economy() {
                 columnDirections={columnsSortMap}
                 onSortChange={updateSortMap}
               />
+
               <tbody>
                 {itemValueTimeseries!.map((groupSeries, index) => (
                   <tr

--- a/src/pages/poe/stash/snapshot/profiles/[id].tsx
+++ b/src/pages/poe/stash/snapshot/profiles/[id].tsx
@@ -145,7 +145,7 @@ export default function ViewProfile() {
           )}
         </StyledCard>
 
-        <div className="flex flex-col space-y-3 lg:space-y-0 lg:flex-row lg:space-x-3">
+        <div className="flex flex-col space-y-3 lg:space-y-0 lg:flex-row lg:space-x-3 text-left">
           <StyledCard title="Value By Tag" className="flex-1">
             <ValueBreakdownTable snapshot={snapshot} />
           </StyledCard>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,10 +10,11 @@ module.exports = {
   ],
   plugins: [require("flowbite/plugin")],
   theme: {
-    // "skin" is a key for tailwind theme-ing
-    // possible change skin to 'content' to fulfill material ui design philosophy
-    // base/inverted used for text
-    // primary/secondary, etc used for colors & backgrounds
+    // Theme Design Principles and Distinctions:
+    // - Color (primary, secondary &  variants)
+    // - Surfaces (backgrounds and components)
+    // - States (such as error states)
+    // - Content (typography and iconography)
     extend: {
       textColor: {
         content: {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36931825/219851694-746f9464-393b-4759-9f3e-2c2614cbec4d.png)

![image](https://user-images.githubusercontent.com/36931825/219851712-9b45152c-48f3-45f3-aa94-a8cb6f584ec0.png)


Basic Alignment of Items on Profile & Econ Page.

Changed 'Econ' text in profile to 'Show Econ' to clarify its use to users. Another solution could be adding an <Info_Icon> tooltip above.

Hover Effects for items in stash profiles & checkbox color changed to theme accent. Could also add a seperate checkbox color tied to theme - another option for people to customize later.

