### PR TITLE
fix - characterSheet & highcharts styling

### DIFF
--- a/src/components/character-level-chart.tsx
+++ b/src/components/character-level-chart.tsx
@@ -8,8 +8,10 @@ import { useRef, useEffect } from "react";
 
 export default function CharacterLevelChart({
   snapshots,
+  props,
 }: {
   snapshots: CharacterSnapshotRecord[];
+  props: any;
 }) {
   console.log("ss", snapshots);
   const chart = useRef<any>();
@@ -54,7 +56,12 @@ export default function CharacterLevelChart({
 
   return (
     <>
-      <HighchartsReact ref={chart} highcharts={Highcharts} options={options} />
+      <HighchartsReact
+        ref={chart}
+        highcharts={Highcharts}
+        options={options}
+        containerProps={{ className: props.className }}
+      />
     </>
   );
 }

--- a/src/pages/poe/character/[characterId].tsx
+++ b/src/pages/poe/character/[characterId].tsx
@@ -184,7 +184,7 @@ export default function Character({ characterSnapshot }) {
             content={`/assets/poe/classes/${currentSnapshot?.characterClass}.png`}
           />
         </Head>
-        <div className="flex space-x-2 ">
+        <div className="grid grid-cols-2 space-x-2 ">
           <StyledCard title="Equipment" className="min-w-[450px]">
             <div className="flex flex-col space-y-2">
               <EquipmentDisplay
@@ -262,8 +262,8 @@ export default function Character({ characterSnapshot }) {
                 </div>
               </div>
             </StyledCard>
-            <StyledCard title={"Progression"} className="flex-1 w-full">
-              <CharacterLevelChart snapshots={characterSnapshots} />
+            <StyledCard title={"Progression"} className="flex-1 w-full ">
+              <CharacterLevelChart snapshots={characterSnapshots} props />
             </StyledCard>
           </div>
         </div>


### PR DESCRIPTION
Fixed a styling bug created by removing titles from cards. Was messing up the flex arrangement inside characterProfile page.

Changed characterProfile page from using flex at the top lvl to grid. This will also allow for better customization when making it mobile friendly.

Also using this solution: https://stackoverflow.com/questions/62078924/how-to-use-styled-from-react-emotion-with-highchartsreact

Added in containerProps that were passed down to the levelprogression highChart.