### PR TITLE
Character Page Overhaul

### DIFF
--- a/src/components/character-stats-display.tsx
+++ b/src/components/character-stats-display.tsx
@@ -53,31 +53,31 @@ export default function CharacterStatsDisplay({
             </div>
             <div className="flex flex-row hover:bg-color-primary-variant ">
               <h3>Armour:</h3>
-              <h5 className="mx-4 text-amber-400 text-right w-full">
+              <h5 className="mx-4 text-neutral-200 text-right w-full">
                 {pobStats.armour}
               </h5>
             </div>
             <div className="flex flex-row hover:bg-color-primary-variant ">
               <h3>Evasion:</h3>
-              <h5 className="mx-4 text-emerald-500 text-right w-full">
+              <h5 className="mx-4 text-neutral-200  text-right w-full">
                 {pobStats.evasion}
               </h5>
             </div>
             <div className="flex flex-row hover:bg-color-primary-variant ">
               <h3>Block:</h3>
-              <h5 className="mx-4 text-neutral-300 text-right w-full">
+              <h5 className="mx-4 text-neutral-200  text-right w-full">
                 {pobStats.blockChance}
               </h5>
             </div>
             <div className="flex flex-row hover:bg-color-primary-variant ">
               <h3 className="w-60 ">Spell Block:</h3>
-              <h5 className="mx-4 text-purple-400 text-right w-full">
+              <h5 className="mx-4 text-neutral-200  text-right w-full">
                 {pobStats.spellBlockChance}
               </h5>
             </div>
             <div className="flex flex-row hover:bg-color-primary-variant ">
               <h3>Supression:</h3>
-              <h5 className="mx-4 text-emerald-300 text-right w-full">
+              <h5 className="mx-4 text-neutral-200 text-right w-full">
                 {pobStats.supression}
               </h5>
             </div>
@@ -104,7 +104,7 @@ export default function CharacterStatsDisplay({
             </div>
             <div className="flex flex-row hover:bg-color-primary-variant ">
               <h3>Chaos: </h3>{" "}
-              <h5 className="mx-4 text-pink-500 text-right w-full">
+              <h5 className="mx-4 text-pink-400 text-right w-full">
                 {pobStats.chaosResist}
               </h5>
             </div>
@@ -114,19 +114,19 @@ export default function CharacterStatsDisplay({
             <div className="flex flex-row hover:bg-color-primary-variant ">
               <h3>Endurance: </h3>{" "}
               <h5 className="mx-4 text-rose-500 text-right w-full">
-                {pobStats.coldResist}
+                Placeholder
               </h5>
             </div>
             <div className="flex flex-row hover:bg-color-primary-variant ">
               <h3>Frenzy: </h3>{" "}
               <h5 className="mx-4 text-lime-400 text-right w-full">
-                {pobStats.fireResist}
+                Placeholder
               </h5>
             </div>
             <div className="flex flex-row hover:bg-color-primary-variant ">
               <h3>Power: </h3>{" "}
               <h5 className="mx-4 text-blue-300 text-right w-full">
-                {pobStats.lightningResist}
+                Placeholder
               </h5>
             </div>
           </div>

--- a/src/components/character-stats-display.tsx
+++ b/src/components/character-stats-display.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { CharacterSnapshotPobStats } from "../__generated__/graphql";
-import StyledButton from "./styled-button";
 
 export default function CharacterStatsDisplay({
   pobStats,
@@ -16,40 +15,121 @@ export default function CharacterStatsDisplay({
   return (
     <>
       <div>
-        <div className="grid grid-cols-4 gap-x-1">
+        <div className="grid grid-cols-1 gap-x-3 w-full h-full">
           <div>
-            <div>Life: {pobStats.life}</div>
-            <div>Energy Shield: {pobStats.energyShield}</div>
-            <div>Armour: {pobStats.armour}</div>
-            <div>Evasion: {pobStats.evasion}</div>
+            <h2 className="text-center">Attributes</h2>
+            <div className="flex flex-row hover:bg-color-primary-variant ">
+              <h3>Str:</h3>{" "}
+              <h5 className="mx-4 text-red-500 text-right w-full">
+                {pobStats.str}
+              </h5>
+            </div>
+            <div className="flex flex-row hover:bg-color-primary-variant ">
+              <h3>Int:</h3>{" "}
+              <h5 className="mx-4 text-blue-500 text-right w-full">
+                {pobStats.int}
+              </h5>
+            </div>
+            <div className="flex flex-row hover:bg-color-primary-variant ">
+              <h3>Dex:</h3>{" "}
+              <h5 className="mx-4 text-green-400 text-right w-full">
+                {pobStats.dex}
+              </h5>
+            </div>
           </div>
-
-          <div>
-            <div>Str: {pobStats.str}</div>
-            <div>Int: {pobStats.int}</div>
-            <div>Dex: {pobStats.dex}</div>
+          <div className="mt-2">
+            <h2 className="text-center">Defenses</h2>
+            <div className="flex flex-row hover:bg-color-primary-variant ">
+              <h3>Life:</h3>
+              <h5 className="mx-4 text-red-500 text-right w-full">
+                {pobStats.life}
+              </h5>
+            </div>
+            <div className="flex flex-row hover:bg-color-primary-variant ">
+              <h3>ES:</h3>
+              <h5 className="mx-4 text-teal-300 text-right w-full">
+                {pobStats.energyShield}
+              </h5>
+            </div>
+            <div className="flex flex-row hover:bg-color-primary-variant ">
+              <h3>Armour:</h3>
+              <h5 className="mx-4 text-amber-400 text-right w-full">
+                {pobStats.armour}
+              </h5>
+            </div>
+            <div className="flex flex-row hover:bg-color-primary-variant ">
+              <h3>Evasion:</h3>
+              <h5 className="mx-4 text-emerald-500 text-right w-full">
+                {pobStats.evasion}
+              </h5>
+            </div>
+            <div className="flex flex-row hover:bg-color-primary-variant ">
+              <h3>Block:</h3>
+              <h5 className="mx-4 text-neutral-300 text-right w-full">
+                {pobStats.blockChance}
+              </h5>
+            </div>
+            <div className="flex flex-row hover:bg-color-primary-variant ">
+              <h3 className="w-60 ">Spell Block:</h3>
+              <h5 className="mx-4 text-purple-400 text-right w-full">
+                {pobStats.spellBlockChance}
+              </h5>
+            </div>
+            <div className="flex flex-row hover:bg-color-primary-variant ">
+              <h3>Supression:</h3>
+              <h5 className="mx-4 text-emerald-300 text-right w-full">
+                {pobStats.supression}
+              </h5>
+            </div>
           </div>
-
-          <div>
-            <div>Cold Res: {pobStats.coldResist}</div>
-            <div>Fire Res: {pobStats.fireResist}</div>
-            <div>Lightning Res: {pobStats.lightningResist}</div>
-            <div>Chaos Res: {pobStats.chaosResist}</div>
+          <div className="mt-2">
+            <h2 className="text-center">Resistances</h2>
+            <div className="flex flex-row hover:bg-color-primary-variant ">
+              <h3>Cold: </h3>{" "}
+              <h5 className="mx-4 text-teal-500 text-right w-full">
+                {pobStats.coldResist}
+              </h5>
+            </div>
+            <div className="flex flex-row hover:bg-color-primary-variant ">
+              <h3>Fire: </h3>{" "}
+              <h5 className="mx-4 text-orange-400 text-right w-full">
+                {pobStats.fireResist}
+              </h5>
+            </div>
+            <div className="flex flex-row hover:bg-color-primary-variant ">
+              <h3>Lightning: </h3>{" "}
+              <h5 className="mx-4 text-yellow-300 text-right w-full">
+                {pobStats.lightningResist}
+              </h5>
+            </div>
+            <div className="flex flex-row hover:bg-color-primary-variant ">
+              <h3>Chaos: </h3>{" "}
+              <h5 className="mx-4 text-pink-500 text-right w-full">
+                {pobStats.chaosResist}
+              </h5>
+            </div>
           </div>
-
-          <div>
-            <div>Block: {pobStats.blockChance}</div>
-            <div>Spell Block: {pobStats.spellBlockChance}</div>
-            <div>Supression: {pobStats.supression}</div>
+          <div className="mt-2">
+            <h2 className="text-center">Charges Placeholder</h2>
+            <div className="flex flex-row hover:bg-color-primary-variant ">
+              <h3>Endurance: </h3>{" "}
+              <h5 className="mx-4 text-rose-500 text-right w-full">
+                {pobStats.coldResist}
+              </h5>
+            </div>
+            <div className="flex flex-row hover:bg-color-primary-variant ">
+              <h3>Frenzy: </h3>{" "}
+              <h5 className="mx-4 text-lime-400 text-right w-full">
+                {pobStats.fireResist}
+              </h5>
+            </div>
+            <div className="flex flex-row hover:bg-color-primary-variant ">
+              <h3>Power: </h3>{" "}
+              <h5 className="mx-4 text-blue-300 text-right w-full">
+                {pobStats.lightningResist}
+              </h5>
+            </div>
           </div>
-        </div>
-        <div>
-          <StyledButton
-            text={"Copy POB Code"}
-            onClick={() => {
-              navigator.clipboard.writeText(pobStats?.pobCode ?? "not found");
-            }}
-          />
         </div>
       </div>
     </>

--- a/src/components/equipment-display.tsx
+++ b/src/components/equipment-display.tsx
@@ -32,16 +32,22 @@ export default function EquipmentDisplay({
 
   return (
     <>
-      <div className="max-w-[400px] ">
-        <div className="grid grid-cols-6 justify-items-center">
-          <div className="col-span-2 row-span-2"></div>
-          <div className="col-span-2 row-span-2">
+      <div className="">
+        {/* //! Swap to 8 grid column and overspecifiy each item slots location:
+        
+      
+    
+        
+        */}
+        <div className="grid grid-cols-8 grid-rows-6 gap-1">
+          {/* Head */}
+          <div className="col-start-4 col-end-6 col-span-2 row-span-2 row-start-1 row-end-3">
             <ItemMouseOver item={helm} items={items}>
-              <Image height={94} width={94} src={helm?.icon!} alt={""} />
+              <Image height={90} width={90} src={helm?.icon!} alt={""} />
             </ItemMouseOver>
           </div>
-          <div className="col-span-2"></div>
-          <div>
+          {/* Amulet */}
+          <div className="col-start-6 row-start-3">
             <ItemMouseOver item={amulet} items={items}>
               <Image
                 loader={myLoader}
@@ -52,93 +58,98 @@ export default function EquipmentDisplay({
               />
             </ItemMouseOver>
           </div>
-          <div></div>
-          <div className="col-span-2 row-span-3  ">
+
+          {/* MainHand */}
+          <div className="col-start-1 col-end-3 row-start-1 row-end-5 col-span-2 row-span-4 ">
             <ItemMouseOver item={weapon} items={items}>
               <Image
                 loader={myLoader}
-                height={200}
+                height={130}
                 width={50 * (weapon?.w ?? 1)}
                 src={weapon?.icon!}
                 alt={""}
               />
             </ItemMouseOver>
           </div>
-          <div className="col-span-2 row-span-3">
+          {/* Body */}
+          <div className="col-start-4 col-end-6 col-span-2 row-span-3 row-start-3 row-end-6">
             <ItemMouseOver item={body} items={items}>
               <Image
                 loader={myLoader}
-                height={200}
-                width={100}
+                height={180}
+                width={90}
                 src={body?.icon!}
                 alt={""}
               />
             </ItemMouseOver>
           </div>
-          <div className="col-span-2 row-span-3">
+          {/* OffHand */}
+          <div className="col-start-7 col-end-9 col-span-2 row-start-1 row-end-5 row-span-4">
             <ItemMouseOver item={offHand} items={items}>
               <Image
                 loader={myLoader}
-                height={200}
+                height={110}
                 width={50 * (offHand?.w ?? 1)}
                 src={offHand?.icon!}
                 alt={""}
               />
             </ItemMouseOver>
           </div>
-          <div></div>
-          <div>
+          {/* RingLeft */}
+          <div className="col-start-3 col-end-4 row-start-4 row-end-5">
             <ItemMouseOver item={ring1} items={items}>
               <Image
                 loader={myLoader}
-                height={40}
-                width={40}
+                height={45}
+                width={45}
                 src={ring1?.icon!}
                 alt={""}
               />
             </ItemMouseOver>
           </div>
-          <div className="col-span-2">
+          {/* Belt */}
+          <div className="col-start-4 col-end-6 row-start-6 row-end-7 col-span-2 row-span-1">
             <ItemMouseOver item={belt} items={items}>
               <Image
                 loader={myLoader}
-                height={40}
-                width={80}
+                height={45}
+                width={90}
                 src={belt?.icon!}
                 alt={""}
               />
             </ItemMouseOver>
           </div>
-          <div>
+          {/* RingRight */}
+          <div className="col-start-6 col-end-7 row-start-4 row-end-5">
             <ItemMouseOver item={ring2} items={items}>
               <Image
                 loader={myLoader}
-                height={40}
-                width={40}
+                height={45}
+                width={45}
                 src={ring2?.icon!}
                 alt={""}
               />
             </ItemMouseOver>
           </div>
-          <div></div>
-          <div className="row-span-2"></div>
-          <div className="col-span-2 row-span-2">
+          {/* Gloves */}
+          <div className="col-start-2 col-end-4 row-start-5 row-end-7 col-span-2 row-span-2">
             <ItemMouseOver item={gloves} items={items}>
               <Image
                 loader={myLoader}
-                height={94}
-                width={94}
+                height={90}
+                width={90}
                 src={gloves?.icon!}
                 alt={""}
               />
             </ItemMouseOver>
           </div>
-          <div className="col-span-2 row-span-2">
+          {/* Boots */}
+          <div className="col-start-6 col-end-8 row-start-5 row-end-7 col-span-2 row-span-2">
             <ItemMouseOver item={boots} items={items}>
               <Image
                 loader={myLoader}
-                height={94}
-                width={94}
+                height={90}
+                width={90}
                 src={boots?.icon!}
                 alt={""}
               />

--- a/src/components/equipment-display.tsx
+++ b/src/components/equipment-display.tsx
@@ -46,7 +46,7 @@ export default function EquipmentDisplay({
           <div className="col-start-4 col-end-6 col-span-2 row-span-2 row-start-1 row-end-3">
             <ItemMouseOver item={helm} items={items}>
               <div className="flex flex-row items-center">
-                <Image height={90} width={90} src={helm?.icon!} alt={""} />
+                <Image height={90} width={105} src={helm?.icon!} alt={""} />
               </div>
             </ItemMouseOver>
           </div>
@@ -56,8 +56,8 @@ export default function EquipmentDisplay({
               <div className="flex flex-row items-center">
                 <Image
                   loader={myLoader}
-                  height={40}
-                  width={40}
+                  height={45}
+                  width={45}
                   src={amulet?.icon!}
                   alt={""}
                 />
@@ -72,7 +72,7 @@ export default function EquipmentDisplay({
                 <Image
                   loader={myLoader}
                   height={130}
-                  width={50 * (weapon?.w ?? 1)}
+                  width={55 * (weapon?.w ?? 1)}
                   src={weapon?.icon!}
                   alt={""}
                 />
@@ -86,7 +86,7 @@ export default function EquipmentDisplay({
                 <Image
                   loader={myLoader}
                   height={180}
-                  width={140}
+                  width={105}
                   src={body?.icon!}
                   alt={""}
                 />
@@ -128,7 +128,7 @@ export default function EquipmentDisplay({
                 <Image
                   loader={myLoader}
                   height={45}
-                  width={90}
+                  width={100}
                   src={belt?.icon!}
                   alt={""}
                 />
@@ -156,7 +156,7 @@ export default function EquipmentDisplay({
                 <Image
                   loader={myLoader}
                   height={90}
-                  width={90}
+                  width={105}
                   src={gloves?.icon!}
                   alt={""}
                 />
@@ -170,7 +170,7 @@ export default function EquipmentDisplay({
                 <Image
                   loader={myLoader}
                   height={90}
-                  width={90}
+                  width={105}
                   src={boots?.icon!}
                   alt={""}
                 />

--- a/src/components/equipment-display.tsx
+++ b/src/components/equipment-display.tsx
@@ -17,11 +17,13 @@ export default function EquipmentDisplay({
   }
 
   const weapon = items.find((i) => i.inventoryId === "Weapon");
-  console.log("WEapon: ", weapon);
+  console.log("Weapon: ", weapon);
   const helm = items.find((i) => i.inventoryId === "Helm");
+  console.log("Helm: ", helm);
   const body = items.find((i) => i.inventoryId === "BodyArmour");
-  console.log("Body: ", body);
+  //console.log("Body: ", body);
   const offHand = items.find((i) => i.inventoryId === "Offhand");
+  console.log("OffHand: ", offHand);
   const gloves = items.find((i) => i.inventoryId === "Gloves");
   const boots = items.find((i) => i.inventoryId === "Boots");
 
@@ -43,116 +45,136 @@ export default function EquipmentDisplay({
           {/* Head */}
           <div className="col-start-4 col-end-6 col-span-2 row-span-2 row-start-1 row-end-3">
             <ItemMouseOver item={helm} items={items}>
-              <Image height={90} width={90} src={helm?.icon!} alt={""} />
+              <div className="flex flex-row items-center">
+                <Image height={90} width={90} src={helm?.icon!} alt={""} />
+              </div>
             </ItemMouseOver>
           </div>
           {/* Amulet */}
           <div className="col-start-6 row-start-3">
             <ItemMouseOver item={amulet} items={items}>
-              <Image
-                loader={myLoader}
-                height={40}
-                width={40}
-                src={amulet?.icon!}
-                alt={""}
-              />
+              <div className="flex flex-row items-center">
+                <Image
+                  loader={myLoader}
+                  height={40}
+                  width={40}
+                  src={amulet?.icon!}
+                  alt={""}
+                />
+              </div>
             </ItemMouseOver>
           </div>
 
           {/* MainHand */}
           <div className="col-start-1 col-end-3 row-start-1 row-end-5 col-span-2 row-span-4 ">
             <ItemMouseOver item={weapon} items={items}>
-              <Image
-                loader={myLoader}
-                height={130}
-                width={50 * (weapon?.w ?? 1)}
-                src={weapon?.icon!}
-                alt={""}
-              />
+              <div className="flex flex-row items-center">
+                <Image
+                  loader={myLoader}
+                  height={130}
+                  width={50 * (weapon?.w ?? 1)}
+                  src={weapon?.icon!}
+                  alt={""}
+                />
+              </div>
             </ItemMouseOver>
           </div>
           {/* Body */}
           <div className="col-start-4 col-end-6 col-span-2 row-span-3 row-start-3 row-end-6">
             <ItemMouseOver item={body} items={items}>
-              <Image
-                loader={myLoader}
-                height={180}
-                width={90}
-                src={body?.icon!}
-                alt={""}
-              />
+              <div className="flex flex-row items-center">
+                <Image
+                  loader={myLoader}
+                  height={180}
+                  width={140}
+                  src={body?.icon!}
+                  alt={""}
+                />
+              </div>
             </ItemMouseOver>
           </div>
           {/* OffHand */}
           <div className="col-start-7 col-end-9 col-span-2 row-start-1 row-end-5 row-span-4">
             <ItemMouseOver item={offHand} items={items}>
-              <Image
-                loader={myLoader}
-                height={110}
-                width={50 * (offHand?.w ?? 1)}
-                src={offHand?.icon!}
-                alt={""}
-              />
+              <div className="flex flex-row items-center">
+                <Image
+                  loader={myLoader}
+                  height={110}
+                  width={50 * (offHand?.w ?? 1)}
+                  src={offHand?.icon!}
+                  alt={""}
+                />
+              </div>
             </ItemMouseOver>
           </div>
           {/* RingLeft */}
           <div className="col-start-3 col-end-4 row-start-4 row-end-5">
             <ItemMouseOver item={ring1} items={items}>
-              <Image
-                loader={myLoader}
-                height={45}
-                width={45}
-                src={ring1?.icon!}
-                alt={""}
-              />
+              <div className="flex flex-row items-center">
+                <Image
+                  loader={myLoader}
+                  height={45}
+                  width={45}
+                  src={ring1?.icon!}
+                  alt={""}
+                />
+              </div>
             </ItemMouseOver>
           </div>
           {/* Belt */}
           <div className="col-start-4 col-end-6 row-start-6 row-end-7 col-span-2 row-span-1">
             <ItemMouseOver item={belt} items={items}>
-              <Image
-                loader={myLoader}
-                height={45}
-                width={90}
-                src={belt?.icon!}
-                alt={""}
-              />
+              <div className="flex flex-row items-center">
+                <Image
+                  loader={myLoader}
+                  height={45}
+                  width={90}
+                  src={belt?.icon!}
+                  alt={""}
+                />
+              </div>
             </ItemMouseOver>
           </div>
           {/* RingRight */}
           <div className="col-start-6 col-end-7 row-start-4 row-end-5">
             <ItemMouseOver item={ring2} items={items}>
-              <Image
-                loader={myLoader}
-                height={45}
-                width={45}
-                src={ring2?.icon!}
-                alt={""}
-              />
+              <div className="flex flex-row items-center">
+                <Image
+                  loader={myLoader}
+                  height={45}
+                  width={45}
+                  src={ring2?.icon!}
+                  alt={""}
+                />
+              </div>
             </ItemMouseOver>
           </div>
           {/* Gloves */}
           <div className="col-start-2 col-end-4 row-start-5 row-end-7 col-span-2 row-span-2">
             <ItemMouseOver item={gloves} items={items}>
-              <Image
-                loader={myLoader}
-                height={90}
-                width={90}
-                src={gloves?.icon!}
-                alt={""}
-              />
+              <div className="flex flex-row items-center">
+                <Image
+                  loader={myLoader}
+                  height={90}
+                  width={90}
+                  src={gloves?.icon!}
+                  alt={""}
+                />
+              </div>
             </ItemMouseOver>
           </div>
           {/* Boots */}
           <div className="col-start-6 col-end-8 row-start-5 row-end-7 col-span-2 row-span-2">
             <ItemMouseOver item={boots} items={items}>
-              <Image
-                loader={myLoader}
-                height={90}
-                width={90}
-                src={boots?.icon!}
-                alt={""}
-              />
+              <div className="flex flex-row items-center">
+                <Image
+                  loader={myLoader}
+                  height={90}
+                  width={90}
+                  src={boots?.icon!}
+                  alt={""}
+                />
+              </div>
             </ItemMouseOver>
           </div>
         </div>

--- a/src/components/equipment-display.tsx
+++ b/src/components/equipment-display.tsx
@@ -17,8 +17,10 @@ export default function EquipmentDisplay({
   }
 
   const weapon = items.find((i) => i.inventoryId === "Weapon");
+  console.log("WEapon: ", weapon);
   const helm = items.find((i) => i.inventoryId === "Helm");
   const body = items.find((i) => i.inventoryId === "BodyArmour");
+  console.log("Body: ", body);
   const offHand = items.find((i) => i.inventoryId === "Offhand");
   const gloves = items.find((i) => i.inventoryId === "Gloves");
   const boots = items.find((i) => i.inventoryId === "Boots");
@@ -30,7 +32,7 @@ export default function EquipmentDisplay({
 
   return (
     <>
-      <div className="max-w-[400px]">
+      <div className="max-w-[400px] ">
         <div className="grid grid-cols-6 justify-items-center">
           <div className="col-span-2 row-span-2"></div>
           <div className="col-span-2 row-span-2">
@@ -51,7 +53,7 @@ export default function EquipmentDisplay({
             </ItemMouseOver>
           </div>
           <div></div>
-          <div className="col-span-2 row-span-3">
+          <div className="col-span-2 row-span-3  ">
             <ItemMouseOver item={weapon} items={items}>
               <Image
                 loader={myLoader}

--- a/src/components/item-mouseover.tsx
+++ b/src/components/item-mouseover.tsx
@@ -20,11 +20,37 @@ export default function ItemMouseOver({
 
   const socketedGems = items?.filter((i) => i.socketedInId === item?.itemId);
 
+  // const test = item?.sockets?.filter((i, index) => index < 2);
+  // const test2 = item?.sockets?.filter((i, index) => index === 3 || index === 2);
+  // console.log("test: ", item, test);
+  // console.log("test2: ", item, test2);
   return (
     <>
       {item && (
         <div
-          className="group relative flex justify-center"
+          className={`group relative flex justify-center bg-opacity-80${
+            item.frameType === 0 ? "bg-color-normal " : null
+          }
+          // magic
+          ${
+            item.frameType === 1
+              ? " bg-indigo-300  bg-opacity-25 border border-color-magic "
+              : null
+          } 
+          // rare
+          ${
+            item.frameType === 2
+              ? "bg-yellow-100 bg-opacity-25 border border-color-rare"
+              : null
+          } 
+          // unique
+          ${
+            item.frameType === 3
+              ? "bg-orange-400 bg-opacity-25 border  border-color-unique"
+              : null
+          } 
+          
+          `}
           onClick={() => {
             console.log(item);
           }}
@@ -42,33 +68,68 @@ export default function ItemMouseOver({
               item?.w! > 1 ? "grid-cols-2" : "grid-cols-1"
             } items-center`}
           >
-            {item?.sockets?.map((s, i) => {
-              const gem = socketedGems?.find((e) => e.socket === i);
-              return (
-                <>
-                  {gem && (
-                    <div
-                      className="items-center"
-                      key={i}
-                      onMouseEnter={() => {
-                        setHoveredGem(gem);
-                      }}
-                      onMouseLeave={() => {
-                        setHoveredGem(null);
-                      }}
-                    >
-                      <Image
-                        loader={myLoader}
-                        height={30}
-                        width={30}
-                        src={gem?.icon ?? ""}
-                        alt={""}
-                      />
-                    </div>
-                  )}
-                </>
-              );
-            })}
+            {/* 1st Row */}
+            {item?.sockets
+              ?.filter((d, index) => index < 2)
+              .map((s, i) => {
+                const gem = socketedGems?.find((e) => e.socket === i);
+                return (
+                  <>
+                    {gem && (
+                      <div
+                        className="flex justify-center"
+                        key={i}
+                        onMouseEnter={() => {
+                          setHoveredGem(gem);
+                        }}
+                        onMouseLeave={() => {
+                          setHoveredGem(null);
+                        }}
+                      >
+                        <Image
+                          loader={myLoader}
+                          height={30}
+                          width={30}
+                          src={gem?.icon ?? ""}
+                          alt={""}
+                        />
+                      </div>
+                    )}
+                  </>
+                );
+              })}
+            {/* 2nd Row */}
+            {item?.sockets
+              ?.filter((i, index) => index === 3 || index === 2)
+              ?.reverse()
+              .map((s, i) => {
+                let newI = i + 2;
+                const gem = socketedGems?.find((e) => e.socket === newI);
+                return (
+                  <>
+                    {gem && (
+                      <div
+                        className="flex justify-center"
+                        key={newI}
+                        onMouseEnter={() => {
+                          setHoveredGem(gem);
+                        }}
+                        onMouseLeave={() => {
+                          setHoveredGem(null);
+                        }}
+                      >
+                        <Image
+                          loader={myLoader}
+                          height={30}
+                          width={30}
+                          src={gem?.icon ?? ""}
+                          alt={""}
+                        />
+                      </div>
+                    )}
+                  </>
+                );
+              })}
           </div>
           {children}
         </div>

--- a/src/components/item-mouseover.tsx
+++ b/src/components/item-mouseover.tsx
@@ -28,7 +28,7 @@ export default function ItemMouseOver({
     <>
       {item && (
         <div
-          className={`group relative flex justify-center bg-opacity-80${
+          className={`group relative flex w-full h-full mx-auto justify-center bg-opacity-80  ${
             item.frameType === 0 ? "bg-color-normal " : null
           }
           // magic

--- a/src/components/item-mouseover.tsx
+++ b/src/components/item-mouseover.tsx
@@ -19,17 +19,22 @@ export default function ItemMouseOver({
   >(null);
 
   const socketedGems = items?.filter((i) => i.socketedInId === item?.itemId);
+  // console.log("SocketedGems:", socketedGems);
 
-  // const test = item?.sockets?.filter((i, index) => index < 2);
-  // const test2 = item?.sockets?.filter((i, index) => index === 3 || index === 2);
-  // console.log("test: ", item, test);
-  // console.log("test2: ", item, test2);
+  // const firstRowGems = item?.sockets?.filter((i, index) => index < 2);
+  // const secondRowGems = item?.sockets?.filter(
+  //   (i, index) => index === 3 || index === 2
+  // );
+  // console.log("firstRowGems: ", item, firstRowGems);
+  // console.log("secondRowGems: ", item, secondRowGems);
   return (
     <>
       {item && (
         <div
-          className={`group relative flex w-full h-full mx-auto justify-center bg-opacity-80  ${
-            item.frameType === 0 ? "bg-color-normal " : null
+          className={`group relative flex w-full h-full mx-auto justify-center   ${
+            item.frameType === 0
+              ? "bg-white bg-opacity-40 border-color-normal border "
+              : null
           }
           // magic
           ${
@@ -63,74 +68,651 @@ export default function ItemMouseOver({
               {hoveredGem && <ItemStatDisplay item={hoveredGem} />}
             </div>
           </div>
-          <div
-            className={`absolute scale-0 group-hover:scale-100 w-full h-full grid ${
-              item?.w! > 1 ? "grid-cols-2" : "grid-cols-1"
-            } items-center`}
-          >
-            {/* 1st Row */}
-            {item?.sockets
-              ?.filter((d, index) => index < 2)
-              .map((s, i) => {
+
+          {/* w-1 items */}
+          {/* lg:group-hover:scale-125 */}
+          {item?.w! === 1 ? (
+            <div className="absolute scale-0 group-hover:scale-100 lg:group-hover:scale-110 w-full h-full grid grid-rows-[_1fr, 3_fr, 3_fr, 3_fr, 1_fr] grid-cols-5 items-center justify-center z-0 ">
+              {item?.sockets?.map((s, i) => {
                 const gem = socketedGems?.find((e) => e.socket === i);
-                return (
-                  <>
-                    {gem && (
-                      <div
-                        className="flex justify-center"
-                        key={i}
-                        onMouseEnter={() => {
-                          setHoveredGem(gem);
-                        }}
-                        onMouseLeave={() => {
-                          setHoveredGem(null);
-                        }}
-                      >
-                        <Image
-                          loader={myLoader}
-                          height={30}
-                          width={30}
-                          src={gem?.icon ?? ""}
-                          alt={""}
-                        />
-                      </div>
-                    )}
-                  </>
-                );
+                const currentSocketGroup = item?.sockets[i - 1]?.group;
+                //console.log("currentSocketGroup", currentSocketGroup);
+
+                if (i === 0) {
+                  return (
+                    <>
+                      <span className="row-start-1 row-end-1"></span>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-2 row-end-3 z-50 col-start-3 col-end-4 ${
+                            gem.support ? " rounded-full" : "rotate-45"
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700  border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  );
+                }
+                if (i === 1 && item?.sockets[i].group === currentSocketGroup) {
+                  return (
+                    <>
+                      <span className="grid row-start-2 row-end-4 w-3 h-1/3 col-start-3 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 ${
+                            gem.support ? " rounded-full" : "rotate-45"
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700  border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  );
+                } else if (i === 1) {
+                  return (
+                    <>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 ${
+                            gem.support ? " rounded-full" : "rotate-45 "
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700  border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  );
+                }
+                if (i === 2 && item?.sockets[i].group === currentSocketGroup) {
+                  return (
+                    <>
+                      <span className="grid row-start-3 row-end-5 w-3 h-1/3 col-start-3 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4 ${
+                            gem.support ? " rounded-full" : "rotate-45"
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700  border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700 border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  );
+                } else if (i === 2) {
+                  return (
+                    <>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4 ${
+                            gem.support ? " rounded-full" : "rotate-45 "
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700 border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700 border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  );
+                }
               })}
-            {/* 2nd Row */}
-            {item?.sockets
-              ?.filter((i, index) => index === 3 || index === 2)
-              ?.reverse()
-              .map((s, i) => {
-                let newI = i + 2;
-                const gem = socketedGems?.find((e) => e.socket === newI);
-                return (
-                  <>
-                    {gem && (
-                      <div
-                        className="flex justify-center"
-                        key={newI}
-                        onMouseEnter={() => {
-                          setHoveredGem(gem);
-                        }}
-                        onMouseLeave={() => {
-                          setHoveredGem(null);
-                        }}
-                      >
-                        <Image
-                          loader={myLoader}
-                          height={30}
-                          width={30}
-                          src={gem?.icon ?? ""}
-                          alt={""}
-                        />
-                      </div>
-                    )}
-                  </>
-                );
+              <span className="row-start-5 row-end-6"></span>
+            </div>
+          ) : null}
+          {/* w-2 items */}
+          {/* w-2 && h-2 - Helms, Gloves, Boots, Shield */}
+
+          {item?.w! === 2 && item?.h! === 2 ? (
+            <div className="absolute scale-0 group-hover:scale-100 lg:group-hover:scale-110 w-full h-full grid grid-rows-[1fr, 10fr, 10fr, _1fr] grid-cols-[_1fr, _10fr, _10fr, 1_fr] items-center justify-center z-0 gap-x-4 gap-y-4 ">
+              {item?.sockets?.map((s, i) => {
+                const gem = socketedGems?.find((e) => e.socket === i);
+                const currentSocketGroup = item?.sockets[i - 1]?.group;
+                console.log("GEM: ", gem);
+                //console.log("currentSocketGroup", currentSocketGroup);
+
+                if (i === 0) {
+                  return (
+                    <>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-2 row-end-3 z-50 col-start-2 col-end-3 ${
+                            gem.support ? " rounded-full " : "rotate-45"
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700  border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  );
+                }
+                if (i === 1 && item?.sockets[i].group === currentSocketGroup) {
+                  return (
+                    <>
+                      <span className="grid row-start-2 row-end-3 w-1/3 h-3 col-start-2 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-2 row-end-3 z-50 col-start-3 col-end-4 ${
+                            gem.support ? " rounded-full" : "rotate-45"
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700  border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  );
+                } else if (i === 1) {
+                  return (
+                    <>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-2 row-end-3 z-50 col-start-3 col-end-4 ${
+                            gem.support ? " rounded-full" : "rotate-45 "
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700  border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  );
+                }
+                if (i === 2 && item?.sockets[i].group === currentSocketGroup) {
+                  return (
+                    <>
+                      <span className="grid row-start-2 row-end-4 w-3 h-1/3 col-start-3 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 ${
+                            gem.support ? " rounded-full" : "rotate-45"
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700  border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700 border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  );
+                } else if (i === 2) {
+                  return (
+                    <>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 ${
+                            gem.support ? " rounded-full" : "rotate-45 "
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700 border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700 border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  );
+                }
+                if (i === 3 && item?.sockets[i].group === currentSocketGroup) {
+                  return (
+                    <>
+                      <span className="grid row-start-3 row-end-4 w-1/3 h-3 col-start-2 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-2 col-end-3 ${
+                            gem.support ? " rounded-full" : "rotate-45"
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700  border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700 border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  );
+                } else if (i === 3) {
+                  return (
+                    <>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-2 col-end-3 ${
+                            gem.support ? " rounded-full" : "rotate-45 "
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700 border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700 border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  );
+                }
               })}
-          </div>
+              <span className="row-start-4 row-end-5"></span>
+            </div>
+          ) : null}
+          {/* w-2 && h-3 - Body, Bows, 2 Handers */}
+          {item?.w! === 2 && item?.h! === 3 ? <div>3</div> : null}
+
           {children}
         </div>
       )}

--- a/src/components/item-mouseover.tsx
+++ b/src/components/item-mouseover.tsx
@@ -31,7 +31,10 @@ export default function ItemMouseOver({
     <>
       {item && (
         <div
-          className={`group relative flex w-full h-full mx-auto justify-center   ${
+          className={`group relative flex w-full h-full mx-auto justify-center  
+          ${item.corrupted ? "border-2 border-red-900 bg-red-400" : null}
+
+          ${
             item.frameType === 0
               ? "bg-white bg-opacity-40 border-color-normal border "
               : null
@@ -54,6 +57,12 @@ export default function ItemMouseOver({
               ? "bg-orange-400 bg-opacity-25 border  border-color-unique"
               : null
           } 
+          ${
+            item.frameType === 9
+              ? "bg-pink-400 bg-opacity-25 border  border-pink-400"
+              : null
+          } 
+          
           
           `}
           onClick={() => {

--- a/src/components/item-mouseover.tsx
+++ b/src/components/item-mouseover.tsx
@@ -345,7 +345,7 @@ export default function ItemMouseOver({
           item?.h! === 2 &&
           item?.inventoryId === "Offhand" ? (
             <div
-              className="absolute scale-0 group-hover:scale-100 bg-pink-700 lg:group-hover:scale-110 w-full h-full grid grid-rows-[_1fr, _1fr, _1fr, _10fr, _10fr, _10fr,  _1fr, _1fr, _1fr] 
+              className="absolute scale-0 group-hover:scale-100  lg:group-hover:scale-110 w-full h-full grid grid-rows-[_1fr, _1fr, _1fr, _10fr, _10fr, _10fr,  _1fr, _1fr, _1fr] 
             grid-cols-[_1fr, _10fr, _10fr, _1fr] items-center justify-center z-0 gap-x-4 gap-y-4 "
             >
               {item?.sockets?.map((s, i) => {

--- a/src/components/item-mouseover.tsx
+++ b/src/components/item-mouseover.tsx
@@ -63,9 +63,9 @@ export default function ItemMouseOver({
           <div
             className={`absolute top-10 left-28 scale-0 rounded z-50 text-xs text-white group-hover:scale-100`}
           >
-            <div className="flex flex-row space-x-5">
-              <ItemStatDisplay item={item} />
+            <div className="flex flex-row space-x-5 ml-10">
               {hoveredGem && <ItemStatDisplay item={hoveredGem} />}
+              <ItemStatDisplay item={item} />
             </div>
           </div>
 

--- a/src/components/item-mouseover.tsx
+++ b/src/components/item-mouseover.tsx
@@ -127,6 +127,21 @@ export default function ItemMouseOver({
                           </div>
                         </div>
                       )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-2 row-end-3 z-50 col-start-3 col-end-4 rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
                     </>
                   );
                 }
@@ -179,6 +194,21 @@ export default function ItemMouseOver({
                           </div>
                         </div>
                       )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
                     </>
                   );
                 } else if (i === 1) {
@@ -227,6 +257,21 @@ export default function ItemMouseOver({
                               alt={""}
                             />
                           </div>
+                        </div>
+                      )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
                         </div>
                       )}
                     </>
@@ -281,6 +326,21 @@ export default function ItemMouseOver({
                           </div>
                         </div>
                       )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4 rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
                     </>
                   );
                 } else if (i === 2) {
@@ -329,6 +389,21 @@ export default function ItemMouseOver({
                               alt={""}
                             />
                           </div>
+                        </div>
+                      )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4 rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
                         </div>
                       )}
                     </>
@@ -403,6 +478,21 @@ export default function ItemMouseOver({
                           </div>
                         </div>
                       )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-2 col-end-3 rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
                     </>
                   );
                 }
@@ -455,6 +545,21 @@ export default function ItemMouseOver({
                           </div>
                         </div>
                       )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center  row-start-4 row-end-5 z-50 col-start-3 col-end-4 rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
                     </>
                   );
                 } else if (i === 1) {
@@ -503,6 +608,21 @@ export default function ItemMouseOver({
                               alt={""}
                             />
                           </div>
+                        </div>
+                      )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4  rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
                         </div>
                       )}
                     </>
@@ -557,6 +677,21 @@ export default function ItemMouseOver({
                           </div>
                         </div>
                       )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-5 row-end-6 z-50 col-start-3 col-end-4rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
                     </>
                   );
                 } else if (i === 2) {
@@ -605,6 +740,21 @@ export default function ItemMouseOver({
                               alt={""}
                             />
                           </div>
+                        </div>
+                      )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center  row-start-5 row-end-6 z-50 col-start-3 col-end-4 rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
                         </div>
                       )}
                     </>
@@ -673,6 +823,21 @@ export default function ItemMouseOver({
                           </div>
                         </div>
                       )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-2 row-end-3 z-50 col-start-2 col-end-3 rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
                     </>
                   );
                 }
@@ -725,6 +890,21 @@ export default function ItemMouseOver({
                           </div>
                         </div>
                       )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-2 row-end-3 z-50 col-start-3 col-end-4 rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
                     </>
                   );
                 } else if (i === 1) {
@@ -773,6 +953,21 @@ export default function ItemMouseOver({
                               alt={""}
                             />
                           </div>
+                        </div>
+                      )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-2 row-end-3 z-50 col-start-3 col-end-4   rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
                         </div>
                       )}
                     </>
@@ -827,6 +1022,21 @@ export default function ItemMouseOver({
                           </div>
                         </div>
                       )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
                     </>
                   );
                 } else if (i === 2) {
@@ -875,6 +1085,21 @@ export default function ItemMouseOver({
                               alt={""}
                             />
                           </div>
+                        </div>
+                      )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
                         </div>
                       )}
                     </>
@@ -929,6 +1154,21 @@ export default function ItemMouseOver({
                           </div>
                         </div>
                       )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-2 col-end-3 rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
                     </>
                   );
                 } else if (i === 3) {
@@ -979,6 +1219,21 @@ export default function ItemMouseOver({
                           </div>
                         </div>
                       )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-2 col-end-3 rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
                     </>
                   );
                 }
@@ -986,9 +1241,749 @@ export default function ItemMouseOver({
               <span className="row-start-4 row-end-5"></span>
             </div>
           ) : null}
-          {/* w-2 && h-3 - Body, Bows, 2 Handers, Scepters*/}
-          {item?.w! === 2 && item?.h! === 3 ? <div>3</div> : null}
 
+          {/* w-2 && h-3 - Body, Bows, 2 Handers, Scepters*/}
+          {(item?.w! === 2 && item?.h! === 3) || item?.h! === 4 ? (
+            <div
+              className="absolute scale-0 group-hover:scale-100  lg:group-hover:scale-110 w-full h-full grid grid-rows-9 
+            grid-cols-[_1fr, _10fr, _10fr, _1fr] items-center justify-center z-0 gap-x-4 gap-y-4 "
+            >
+              {item?.sockets?.map((s, i) => {
+                const gem = socketedGems?.find((e) => e.socket === i);
+                const currentSocketGroup = item?.sockets[i - 1]?.group;
+                //console.log("currentSocketGroup", currentSocketGroup);
+
+                if (i === 0) {
+                  return (
+                    <>
+                      <span className="row-start-1 row-span-2"></span>
+                      <span className="row-start-7 row-span-2"></span>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-2 col-end-3 ${
+                            gem.support ? " rounded-full " : "rotate-45"
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700  border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-2 col-end-3 rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
+                    </>
+                  );
+                }
+                if (i === 1 && item?.sockets[i].group === currentSocketGroup) {
+                  return (
+                    <>
+                      <span className="grid row-start-3 row-end-4 w-1/3 h-3 col-start-2 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 ${
+                            gem.support ? " rounded-full" : "rotate-45"
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700  border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4  rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
+                    </>
+                  );
+                } else if (i === 1) {
+                  return (
+                    <>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 ${
+                            gem.support ? " rounded-full" : "rotate-45 "
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700  border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4  rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
+                    </>
+                  );
+                }
+                if (i === 2 && item?.sockets[i].group === currentSocketGroup) {
+                  return (
+                    <>
+                      <span className="grid row-start-3 row-end-5 w-3 h-1/3 col-start-3 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4 ${
+                            gem.support ? " rounded-full" : "rotate-45"
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700  border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700 border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4   rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
+                    </>
+                  );
+                } else if (i === 2) {
+                  return (
+                    <>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4 ${
+                            gem.support ? " rounded-full" : "rotate-45 "
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700 border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700 border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4   rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
+                    </>
+                  );
+                }
+                if (i === 3 && item?.sockets[i].group === currentSocketGroup) {
+                  return (
+                    <>
+                      <span className="grid row-start-4 row-end-5 w-1/3 h-3 col-start-2 col-end-4 mx-auto bg-yellow-400 z-0 "></span>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-2 col-end-3 ${
+                            gem.support ? " rounded-full" : "rotate-45"
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700  border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-2 col-end-3  rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
+                    </>
+                  );
+                } else if (i === 3) {
+                  return (
+                    <>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-2 col-end-3 ${
+                            gem.support ? " rounded-full" : "rotate-45 "
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700  border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-2 col-end-3 rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
+                    </>
+                  );
+                }
+                if (i === 4 && item?.sockets[i].group === currentSocketGroup) {
+                  return (
+                    <>
+                      <span className="grid row-start-4 row-end-6 w-3 h-1/3 col-start-2 col-end-3 mx-auto bg-yellow-400 z-0  "></span>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-5 row-end-6 z-50 col-start-2 col-end-3 ${
+                            gem.support ? " rounded-full" : "rotate-45"
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700  border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700 border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125sss"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-5 row-end-6 z-50 col-start-2 col-end-3 rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
+                    </>
+                  );
+                } else if (i === 4) {
+                  return (
+                    <>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-5 row-end-6 z-50 col-start-2 col-end-3 ${
+                            gem.support ? " rounded-full" : "rotate-45 "
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700 border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700 border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-5 row-end-6 z-50 col-start-2 col-end-3 rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
+                    </>
+                  );
+                }
+                if (i === 5 && item?.sockets[i].group === currentSocketGroup) {
+                  return (
+                    <>
+                      <span className="grid row-start-5 row-end-6 w-1/3 h-3 col-start-2 col-end-4 mx-auto bg-yellow-400 z-0 "></span>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-5 row-end-6 z-50 col-start-3 col-end-4 ${
+                            gem.support ? " rounded-full" : "rotate-45"
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700  border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-5 row-end-6 z-50 col-start-3 col-end-4rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
+                    </>
+                  );
+                } else if (i === 5) {
+                  return (
+                    <>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-2 col-end-3 ${
+                            gem.support ? " rounded-full" : "rotate-45 "
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700  border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                      {!gem && (
+                        <div
+                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4 rounded-full 
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div className="rounded-full w-7 h-7 bg-slate-700 border-2 border-yellow-400"></div>
+                        </div>
+                      )}
+                    </>
+                  );
+                }
+              })}
+            </div>
+          ) : null}
           {children}
         </div>
       )}

--- a/src/components/item-mouseover.tsx
+++ b/src/components/item-mouseover.tsx
@@ -63,7 +63,7 @@ export default function ItemMouseOver({
           <div
             className={`absolute top-10 left-28 scale-0 rounded z-50 text-xs text-white group-hover:scale-100`}
           >
-            <div className="flex flex-row space-x-5 ml-10">
+            <div className="flex flex-col z-100 pl-10">
               {hoveredGem && <ItemStatDisplay item={hoveredGem} />}
               <ItemStatDisplay item={item} />
             </div>
@@ -339,14 +339,290 @@ export default function ItemMouseOver({
             </div>
           ) : null}
           {/* w-2 items */}
-          {/* w-2 && h-2 - Helms, Gloves, Boots, Shield */}
 
-          {item?.w! === 2 && item?.h! === 2 ? (
-            <div className="absolute scale-0 group-hover:scale-100 lg:group-hover:scale-110 w-full h-full grid grid-rows-[1fr, 10fr, 10fr, _1fr] grid-cols-[_1fr, _10fr, _10fr, 1_fr] items-center justify-center z-0 gap-x-4 gap-y-4 ">
+          {/* w-2 && h-2 - Shields*/}
+          {item?.w! === 2 &&
+          item?.h! === 2 &&
+          item?.inventoryId === "Offhand" ? (
+            <div
+              className="absolute scale-0 group-hover:scale-100 bg-pink-700 lg:group-hover:scale-110 w-full h-full grid grid-rows-[_1fr, _1fr, _1fr, _10fr, _10fr, _10fr,  _1fr, _1fr, _1fr] 
+            grid-cols-[_1fr, _10fr, _10fr, _1fr] items-center justify-center z-0 gap-x-4 gap-y-4 "
+            >
               {item?.sockets?.map((s, i) => {
                 const gem = socketedGems?.find((e) => e.socket === i);
                 const currentSocketGroup = item?.sockets[i - 1]?.group;
-                console.log("GEM: ", gem);
+                //console.log("currentSocketGroup", currentSocketGroup);
+
+                if (i === 0) {
+                  return (
+                    <>
+                      <span className="row-start-1 row-span-3"></span>
+                      <span className="row-start-6 row-span-3"></span>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-2 col-end-3 ${
+                            gem.support ? " rounded-full " : "rotate-45"
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700  border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  );
+                }
+                if (i === 1 && item?.sockets[i].group === currentSocketGroup) {
+                  return (
+                    <>
+                      <span className="grid row-start-4 row-end-5 w-1/3 h-3 col-start-2 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4 ${
+                            gem.support ? " rounded-full" : "rotate-45"
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700  border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  );
+                } else if (i === 1) {
+                  return (
+                    <>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4 ${
+                            gem.support ? " rounded-full" : "rotate-45 "
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700  border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  );
+                }
+                if (i === 2 && item?.sockets[i].group === currentSocketGroup) {
+                  return (
+                    <>
+                      <span className="grid row-start-4 row-end-6 w-3 h-1/3 col-start-3 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-5 row-end-6 z-50 col-start-3 col-end-4 ${
+                            gem.support ? " rounded-full" : "rotate-45"
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700  border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700 border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700  border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  );
+                } else if (i === 2) {
+                  return (
+                    <>
+                      {gem && (
+                        <div
+                          className={`flex justify-center row-start-5 row-end-6 z-50 col-start-3 col-end-4 ${
+                            gem.support ? " rounded-full" : "rotate-45 "
+                          } 
+                        
+                        ${
+                          gem.gemColor === "D"
+                            ? "bg-slate-700 border-2  border-green-600  hover:border-green-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "I"
+                            ? "bg-slate-700 border-2  border-blue-600  hover:border-blue-400 "
+                            : null
+                        }
+                        ${
+                          gem.gemColor === "S"
+                            ? "bg-slate-700 border-2  border-red-600  hover:border-red-400 "
+                            : null
+                        }
+                       
+                        `}
+                          key={i}
+                          onMouseEnter={() => {
+                            setHoveredGem(gem);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredGem(null);
+                          }}
+                        >
+                          <div
+                            className={`${gem.support ? null : "-rotate-45 "}`}
+                          >
+                            <Image
+                              loader={myLoader}
+                              height={30}
+                              width={30}
+                              className="scale-125"
+                              src={gem?.icon ?? ""}
+                              alt={""}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  );
+                }
+              })}
+              <span className="row-start-4 row-end-5"></span>
+            </div>
+          ) : null}
+          {/* w-2 && h-2 - Helms, Gloves, Boots*/}
+          {item?.w! === 2 &&
+          item?.h! === 2 &&
+          item?.inventoryId !== "Offhand" ? (
+            <div className="absolute scale-0 group-hover:scale-100 lg:group-hover:scale-110 w-full h-full grid grid-rows-[1fr, 10fr, 10fr, _1fr] grid-cols-[1px, _10fr, _10fr, 1px] items-center justify-center z-0 gap-x-4 gap-y-4 ">
+              {item?.sockets?.map((s, i) => {
+                const gem = socketedGems?.find((e) => e.socket === i);
+                const currentSocketGroup = item?.sockets[i - 1]?.group;
+                //console.log("GEM: ", gem);
                 //console.log("currentSocketGroup", currentSocketGroup);
 
                 if (i === 0) {
@@ -710,7 +986,7 @@ export default function ItemMouseOver({
               <span className="row-start-4 row-end-5"></span>
             </div>
           ) : null}
-          {/* w-2 && h-3 - Body, Bows, 2 Handers */}
+          {/* w-2 && h-3 - Body, Bows, 2 Handers, Scepters*/}
           {item?.w! === 2 && item?.h! === 3 ? <div>3</div> : null}
 
           {children}

--- a/src/components/item-mouseover.tsx
+++ b/src/components/item-mouseover.tsx
@@ -70,9 +70,9 @@ export default function ItemMouseOver({
           </div>
 
           {/* w-1 items */}
-          {/* lg:group-hover:scale-125 */}
+          {/* lg:group-hover:scale-150 */}
           {item?.w! === 1 ? (
-            <div className="absolute scale-0 group-hover:scale-100 lg:group-hover:scale-110 w-full h-full grid grid-rows-[_1fr, 3_fr, 3_fr, 3_fr, 1_fr] grid-cols-5 items-center justify-center z-0 ">
+            <div className="absolute scale-0 group-hover:scale-100  w-full h-full grid grid-rows-[1px, 3_fr, 3_fr, 3_fr, 1px] grid-cols-3 items-center justify-center z-0 ">
               {item?.sockets?.map((s, i) => {
                 const gem = socketedGems?.find((e) => e.socket === i);
                 const currentSocketGroup = item?.sockets[i - 1]?.group;
@@ -84,7 +84,7 @@ export default function ItemMouseOver({
                       <span className="row-start-1 row-end-1"></span>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-2 row-end-3 z-50 col-start-3 col-end-4 ${
+                          className={`flex justify-center scale-90 row-start-2 row-end-3 z-50 col-start-2 col-end-3 ${
                             gem.support ? " rounded-full" : "rotate-45"
                           } 
                         
@@ -120,7 +120,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -129,7 +129,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-2 row-end-3 z-50 col-start-3 col-end-4 rounded-full 
+                          className={`flex justify-center scale-90 row-start-2 row-end-3 z-50 col-start-2 col-end-3 rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -148,10 +148,10 @@ export default function ItemMouseOver({
                 if (i === 1 && item?.sockets[i].group === currentSocketGroup) {
                   return (
                     <>
-                      <span className="grid row-start-2 row-end-4 w-3 h-1/3 col-start-3 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
+                      <span className="grid row-start-2 row-end-4 w-3 h-1/3 col-start-2 col-end-3 mx-auto bg-yellow-400 z-0  "></span>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 ${
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-2 col-end-3 ${
                             gem.support ? " rounded-full" : "rotate-45"
                           } 
                         
@@ -187,7 +187,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -196,7 +196,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 rounded-full 
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-2 col-end-3 rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -216,7 +216,7 @@ export default function ItemMouseOver({
                     <>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 ${
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-2 col-end-3 ${
                             gem.support ? " rounded-full" : "rotate-45 "
                           } 
                         
@@ -252,7 +252,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -261,7 +261,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 rounded-full 
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-2 col-end-3 rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -280,10 +280,10 @@ export default function ItemMouseOver({
                 if (i === 2 && item?.sockets[i].group === currentSocketGroup) {
                   return (
                     <>
-                      <span className="grid row-start-3 row-end-5 w-3 h-1/3 col-start-3 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
+                      <span className="grid row-start-3 row-end-5 w-3 h-1/3 col-start-2 col-end-3 mx-auto bg-yellow-400 z-0  "></span>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4 ${
+                          className={`flex justify-center scale-90 row-start-4 row-end-5 z-50 col-start-2 col-end-3 ${
                             gem.support ? " rounded-full" : "rotate-45"
                           } 
                         
@@ -319,7 +319,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -328,7 +328,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4 rounded-full 
+                          className={`flex justify-center scale-90 row-start-4 row-end-5 z-50 col-start-2 col-end-3 rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -348,7 +348,7 @@ export default function ItemMouseOver({
                     <>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4 ${
+                          className={`flex justify-center scale-90 row-start-4 row-end-5 z-50 col-start-2 col-end-3 ${
                             gem.support ? " rounded-full" : "rotate-45 "
                           } 
                         
@@ -384,7 +384,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -393,7 +393,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4 rounded-full 
+                          className={`flex justify-center scale-90 row-start-4 row-end-5 z-50 col-start-2 col-end-3 rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -420,8 +420,8 @@ export default function ItemMouseOver({
           item?.h! === 2 &&
           item?.inventoryId === "Offhand" ? (
             <div
-              className="absolute scale-0 group-hover:scale-100  lg:group-hover:scale-110 w-full h-full grid grid-rows-[_1fr, _1fr, _1fr, _10fr, _10fr, _10fr,  _1fr, _1fr, _1fr] 
-            grid-cols-[_1fr, _10fr, _10fr, _1fr] items-center justify-center z-0 gap-x-4 gap-y-4 "
+              className="absolute scale-0 group-hover:scale-100  w-full h-full grid grid-rows-[_1fr, _1fr, _1fr, _10fr, _10fr, _10fr,  _1fr, _1fr, _1fr] 
+            grid-cols-[_1fr, _10fr, _10fr, _1fr] items-center justify-center z-0 gap-x-2 gap-y-2 "
             >
               {item?.sockets?.map((s, i) => {
                 const gem = socketedGems?.find((e) => e.socket === i);
@@ -435,7 +435,7 @@ export default function ItemMouseOver({
                       <span className="row-start-6 row-span-3"></span>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-2 col-end-3 ${
+                          className={`flex justify-center scale-90 row-start-4 row-end-5 z-50 col-start-2 col-end-3 ${
                             gem.support ? " rounded-full " : "rotate-45"
                           } 
                         
@@ -471,7 +471,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -480,7 +480,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-2 col-end-3 rounded-full 
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-2 col-end-3 rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -502,7 +502,7 @@ export default function ItemMouseOver({
                       <span className="grid row-start-4 row-end-5 w-1/3 h-3 col-start-2 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4 ${
+                          className={`flex justify-center scale-90 row-start-4 row-end-5 z-50 col-start-3 col-end-4 ${
                             gem.support ? " rounded-full" : "rotate-45"
                           } 
                         
@@ -538,7 +538,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -547,7 +547,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center  row-start-4 row-end-5 z-50 col-start-3 col-end-4 rounded-full 
+                          className={`flex justify-center scale-90  row-start-4 row-end-5 z-50 col-start-3 col-end-4 rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -567,7 +567,7 @@ export default function ItemMouseOver({
                     <>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4 ${
+                          className={`flex justify-center scale-90 row-start-4 row-end-5 z-50 col-start-3 col-end-4 ${
                             gem.support ? " rounded-full" : "rotate-45 "
                           } 
                         
@@ -603,7 +603,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -612,7 +612,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4  rounded-full 
+                          className={`flex justify-center scale-90 row-start-4 row-end-5 z-50 col-start-3 col-end-4  rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -634,7 +634,7 @@ export default function ItemMouseOver({
                       <span className="grid row-start-4 row-end-6 w-3 h-1/3 col-start-3 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-5 row-end-6 z-50 col-start-3 col-end-4 ${
+                          className={`flex justify-center scale-90 row-start-5 row-end-6 z-50 col-start-3 col-end-4 ${
                             gem.support ? " rounded-full" : "rotate-45"
                           } 
                         
@@ -670,7 +670,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -679,7 +679,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-5 row-end-6 z-50 col-start-3 col-end-4rounded-full 
+                          className={`flex justify-center scale-90 row-start-5 row-end-6 z-50 col-start-3 col-end-4rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -699,7 +699,7 @@ export default function ItemMouseOver({
                     <>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-5 row-end-6 z-50 col-start-3 col-end-4 ${
+                          className={`flex justify-center scale-90 row-start-5 row-end-6 z-50 col-start-3 col-end-4 ${
                             gem.support ? " rounded-full" : "rotate-45 "
                           } 
                         
@@ -735,7 +735,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -744,7 +744,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center  row-start-5 row-end-6 z-50 col-start-3 col-end-4 rounded-full 
+                          className={`flex justify-center scale-90  row-start-5 row-end-6 z-50 col-start-3 col-end-4 rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -768,7 +768,7 @@ export default function ItemMouseOver({
           {item?.w! === 2 &&
           item?.h! === 2 &&
           item?.inventoryId !== "Offhand" ? (
-            <div className="absolute scale-0 group-hover:scale-100 lg:group-hover:scale-110 w-full h-full grid grid-rows-[1fr, 10fr, 10fr, _1fr] grid-cols-[1px, _10fr, _10fr, 1px] items-center justify-center z-0 gap-x-4 gap-y-4 ">
+            <div className="absolute scale-0 group-hover:scale-100  w-full h-full grid grid-rows-[1px, _10fr, _10fr, 1px] grid-cols-[1px, _10fr, _10fr, 1px] items-center justify-center z-0 gap-x-3 gap-y-3 ">
               {item?.sockets?.map((s, i) => {
                 const gem = socketedGems?.find((e) => e.socket === i);
                 const currentSocketGroup = item?.sockets[i - 1]?.group;
@@ -780,7 +780,7 @@ export default function ItemMouseOver({
                     <>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-2 row-end-3 z-50 col-start-2 col-end-3 ${
+                          className={`flex justify-center scale-90 row-start-2 row-end-3 z-50 col-start-2 col-end-3  ${
                             gem.support ? " rounded-full " : "rotate-45"
                           } 
                         
@@ -816,7 +816,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -825,7 +825,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-2 row-end-3 z-50 col-start-2 col-end-3 rounded-full 
+                          className={`flex justify-center scale-90 row-start-2 row-end-3 z-50 col-start-2 col-end-3 rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -847,7 +847,7 @@ export default function ItemMouseOver({
                       <span className="grid row-start-2 row-end-3 w-1/3 h-3 col-start-2 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-2 row-end-3 z-50 col-start-3 col-end-4 ${
+                          className={`flex justify-center scale-90 row-start-2 row-end-3 z-50 col-start-3 col-end-4 ${
                             gem.support ? " rounded-full" : "rotate-45"
                           } 
                         
@@ -883,7 +883,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -892,7 +892,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-2 row-end-3 z-50 col-start-3 col-end-4 rounded-full 
+                          className={`flex justify-center scale-90 row-start-2 row-end-3 z-50 col-start-3 col-end-4 rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -912,7 +912,7 @@ export default function ItemMouseOver({
                     <>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-2 row-end-3 z-50 col-start-3 col-end-4 ${
+                          className={`flex justify-center scale-90 row-start-2 row-end-3 z-50 col-start-3 col-end-4 ${
                             gem.support ? " rounded-full" : "rotate-45 "
                           } 
                         
@@ -948,7 +948,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -957,7 +957,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-2 row-end-3 z-50 col-start-3 col-end-4   rounded-full 
+                          className={`flex justify-center scale-90 row-start-2 row-end-3 z-50 col-start-3 col-end-4   rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -979,7 +979,7 @@ export default function ItemMouseOver({
                       <span className="grid row-start-2 row-end-4 w-3 h-1/3 col-start-3 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 ${
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-3 col-end-4 ${
                             gem.support ? " rounded-full" : "rotate-45"
                           } 
                         
@@ -1015,7 +1015,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -1024,7 +1024,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 rounded-full 
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-3 col-end-4 rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -1044,7 +1044,7 @@ export default function ItemMouseOver({
                     <>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 ${
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-3 col-end-4 ${
                             gem.support ? " rounded-full" : "rotate-45 "
                           } 
                         
@@ -1080,7 +1080,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -1089,7 +1089,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 rounded-full 
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-3 col-end-4 rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -1111,7 +1111,7 @@ export default function ItemMouseOver({
                       <span className="grid row-start-3 row-end-4 w-1/3 h-3 col-start-2 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-2 col-end-3 ${
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-2 col-end-3 ${
                             gem.support ? " rounded-full" : "rotate-45"
                           } 
                         
@@ -1147,7 +1147,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -1156,7 +1156,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-2 col-end-3 rounded-full 
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-2 col-end-3 rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -1176,7 +1176,7 @@ export default function ItemMouseOver({
                     <>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-2 col-end-3 ${
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-2 col-end-3 ${
                             gem.support ? " rounded-full" : "rotate-45 "
                           } 
                         
@@ -1212,7 +1212,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -1221,7 +1221,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-2 col-end-3 rounded-full 
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-2 col-end-3 rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -1245,8 +1245,8 @@ export default function ItemMouseOver({
           {/* w-2 && h-3 - Body, Bows, 2 Handers, Scepters*/}
           {(item?.w! === 2 && item?.h! === 3) || item?.h! === 4 ? (
             <div
-              className="absolute scale-0 group-hover:scale-100  lg:group-hover:scale-110 w-full h-full grid grid-rows-9 
-            grid-cols-[_1fr, _10fr, _10fr, _1fr] items-center justify-center z-0 gap-x-4 gap-y-4 "
+              className="absolute scale-0 group-hover:scale-100  w-full h-full grid grid-rows-7 
+            grid-cols-[1px, _10fr, _10fr, 1px] items-center justify-center z-0 gap-x-3 gap-y-2 "
             >
               {item?.sockets?.map((s, i) => {
                 const gem = socketedGems?.find((e) => e.socket === i);
@@ -1256,11 +1256,11 @@ export default function ItemMouseOver({
                 if (i === 0) {
                   return (
                     <>
-                      <span className="row-start-1 row-span-2"></span>
-                      <span className="row-start-7 row-span-2"></span>
+                      <span className="row-start-1 row-span-1"></span>
+                      <span className="row-start-5 row-span-1"></span>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-2 col-end-3 ${
+                          className={`flex justify-center scale-90 row-start-2 row-end-3 z-50 col-start-2 col-end-3 ${
                             gem.support ? " rounded-full " : "rotate-45"
                           } 
                         
@@ -1296,7 +1296,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -1305,7 +1305,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-2 col-end-3 rounded-full 
+                          className={`flex justify-center scale-90 row-start-2 row-end-3 z-50 col-start-2 col-end-3 rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -1324,10 +1324,10 @@ export default function ItemMouseOver({
                 if (i === 1 && item?.sockets[i].group === currentSocketGroup) {
                   return (
                     <>
-                      <span className="grid row-start-3 row-end-4 w-1/3 h-3 col-start-2 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
+                      <span className="grid row-start-2 row-end-3 w-1/3 h-3 col-start-2 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 ${
+                          className={`flex justify-center scale-90 row-start-2 row-end-3 z-50 col-start-3 col-end-4 ${
                             gem.support ? " rounded-full" : "rotate-45"
                           } 
                         
@@ -1363,7 +1363,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -1372,7 +1372,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4  rounded-full 
+                          className={`flex justify-center scale-90 row-start-2 row-end-3 z-50 col-start-3 col-end-4  rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -1392,7 +1392,7 @@ export default function ItemMouseOver({
                     <>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4 ${
+                          className={`flex justify-center scale-90 row-start-2 row-end-3 z-50 col-start-3 col-end-4 ${
                             gem.support ? " rounded-full" : "rotate-45 "
                           } 
                         
@@ -1428,7 +1428,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -1437,7 +1437,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-3 row-end-4 z-50 col-start-3 col-end-4  rounded-full 
+                          className={`flex justify-center scale-90 row-start-2 row-end-3 z-50 col-start-3 col-end-4  rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -1456,10 +1456,10 @@ export default function ItemMouseOver({
                 if (i === 2 && item?.sockets[i].group === currentSocketGroup) {
                   return (
                     <>
-                      <span className="grid row-start-3 row-end-5 w-3 h-1/3 col-start-3 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
+                      <span className="grid row-start-2 row-end-4 w-3 h-1/3 col-start-3 col-end-4 mx-auto bg-yellow-400 z-0  "></span>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4 ${
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-3 col-end-4 ${
                             gem.support ? " rounded-full" : "rotate-45"
                           } 
                         
@@ -1495,7 +1495,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -1504,7 +1504,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4   rounded-full 
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-3 col-end-4   rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -1524,7 +1524,7 @@ export default function ItemMouseOver({
                     <>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4 ${
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-3 col-end-4 ${
                             gem.support ? " rounded-full" : "rotate-45 "
                           } 
                         
@@ -1560,7 +1560,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -1569,7 +1569,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4   rounded-full 
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-3 col-end-4   rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -1588,10 +1588,10 @@ export default function ItemMouseOver({
                 if (i === 3 && item?.sockets[i].group === currentSocketGroup) {
                   return (
                     <>
-                      <span className="grid row-start-4 row-end-5 w-1/3 h-3 col-start-2 col-end-4 mx-auto bg-yellow-400 z-0 "></span>
+                      <span className="grid row-start-3 row-end-4 w-1/3 h-3 col-start-2 col-end-4 mx-auto bg-yellow-400 z-0 "></span>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-2 col-end-3 ${
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-2 col-end-3 ${
                             gem.support ? " rounded-full" : "rotate-45"
                           } 
                         
@@ -1627,7 +1627,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -1636,7 +1636,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-2 col-end-3  rounded-full 
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-2 col-end-3  rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -1656,7 +1656,7 @@ export default function ItemMouseOver({
                     <>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-2 col-end-3 ${
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-2 col-end-3 ${
                             gem.support ? " rounded-full" : "rotate-45 "
                           } 
                         
@@ -1692,7 +1692,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -1701,7 +1701,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-2 col-end-3 rounded-full 
+                          className={`flex justify-center scale-90 row-start-3 row-end-4 z-50 col-start-2 col-end-3 rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -1720,10 +1720,10 @@ export default function ItemMouseOver({
                 if (i === 4 && item?.sockets[i].group === currentSocketGroup) {
                   return (
                     <>
-                      <span className="grid row-start-4 row-end-6 w-3 h-1/3 col-start-2 col-end-3 mx-auto bg-yellow-400 z-0  "></span>
+                      <span className="grid row-start-3 row-end-5 w-3 h-1/3 col-start-2 col-end-3 mx-auto bg-yellow-400 z-0  "></span>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-5 row-end-6 z-50 col-start-2 col-end-3 ${
+                          className={`flex justify-center scale-90 row-start-4 row-end-5 z-50 col-start-2 col-end-3 ${
                             gem.support ? " rounded-full" : "rotate-45"
                           } 
                         
@@ -1768,7 +1768,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-5 row-end-6 z-50 col-start-2 col-end-3 rounded-full 
+                          className={`flex justify-center scale-90 row-start-4 row-end-5 z-50 col-start-2 col-end-3 rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -1788,7 +1788,7 @@ export default function ItemMouseOver({
                     <>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-5 row-end-6 z-50 col-start-2 col-end-3 ${
+                          className={`flex justify-center scale-90 row-start-4 row-end-5 z-50 col-start-2 col-end-3 ${
                             gem.support ? " rounded-full" : "rotate-45 "
                           } 
                         
@@ -1824,7 +1824,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -1833,7 +1833,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-5 row-end-6 z-50 col-start-2 col-end-3 rounded-full 
+                          className={`flex justify-center scale-90 row-start-4 row-end-5 z-50 col-start-2 col-end-3 rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -1852,10 +1852,10 @@ export default function ItemMouseOver({
                 if (i === 5 && item?.sockets[i].group === currentSocketGroup) {
                   return (
                     <>
-                      <span className="grid row-start-5 row-end-6 w-1/3 h-3 col-start-2 col-end-4 mx-auto bg-yellow-400 z-0 "></span>
+                      <span className="grid row-start-4 row-end-5 w-1/3 h-3 col-start-2 col-end-4 mx-auto bg-yellow-400 z-0 "></span>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-5 row-end-6 z-50 col-start-3 col-end-4 ${
+                          className={`flex justify-center scale-90 row-start-4 row-end-5 z-50 col-start-3 col-end-4 ${
                             gem.support ? " rounded-full" : "rotate-45"
                           } 
                         
@@ -1891,7 +1891,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -1900,7 +1900,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-5 row-end-6 z-50 col-start-3 col-end-4rounded-full 
+                          className={`flex justify-center scale-90 row-start-4 row-end-5 z-50 col-start-3 col-end-4rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {
@@ -1920,7 +1920,7 @@ export default function ItemMouseOver({
                     <>
                       {gem && (
                         <div
-                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-2 col-end-3 ${
+                          className={`flex justify-center scale-90 row-start-4 row-end-5 z-50 col-start-2 col-end-3 ${
                             gem.support ? " rounded-full" : "rotate-45 "
                           } 
                         
@@ -1956,7 +1956,7 @@ export default function ItemMouseOver({
                               loader={myLoader}
                               height={30}
                               width={30}
-                              className="scale-125"
+                              className="scale-150"
                               src={gem?.icon ?? ""}
                               alt={""}
                             />
@@ -1965,7 +1965,7 @@ export default function ItemMouseOver({
                       )}
                       {!gem && (
                         <div
-                          className={`flex justify-center row-start-4 row-end-5 z-50 col-start-3 col-end-4 rounded-full 
+                          className={`flex justify-center scale-90 row-start-4 row-end-5 z-50 col-start-3 col-end-4 rounded-full 
                         `}
                           key={i}
                           onMouseEnter={() => {

--- a/src/components/item-mouseover.tsx
+++ b/src/components/item-mouseover.tsx
@@ -32,7 +32,7 @@ export default function ItemMouseOver({
       {item && (
         <div
           className={`group relative flex w-full h-full mx-auto justify-center  
-          ${item.corrupted ? "border-2 border-red-900 bg-red-400" : null}
+          ${item.corrupted ? " border-red-900 bg-red-400" : null}
 
           ${
             item.frameType === 0

--- a/src/components/secondary-equipment-display.tsx
+++ b/src/components/secondary-equipment-display.tsx
@@ -18,11 +18,60 @@ export default function SecondaryEquipmentDisplay({
 
   const flasks = items.filter((i) => i.inventoryId === "Flask");
   const jewels = items.filter((i) => i.inventoryId === "PassiveJewels");
+  const nonUniqueJewels = items.filter(
+    (i) => i.inventoryId === "PassiveJewels" && i.frameType !== 3
+  );
+
+  //console.log("jewels: ", jewels);
+  //console.log("nonUniqueJewels: ", nonUniqueJewels);
+
+  // Clusters
+  const largeClusterJewels = jewels.filter(
+    (i) => i.typeLine === "Large Cluster Jewel"
+  );
+  //console.log("largeClusterJewels: ", largeClusterJewels);
+
+  const mediumClusterJewels = jewels.filter(
+    (i) => i.typeLine === "Medium Cluster Jewel"
+  );
+  //console.log("mediumClusterJewels: ", mediumClusterJewels);
+
+  const smallClusterJewels = jewels.filter(
+    (i) => i.typeLine === "Small Cluster Jewel"
+  );
+  //console.log("smallClusterJewels: ", smallClusterJewels);
+
+  //Unique Jewels
+  const uniqueJewels = items.filter(
+    (i) => i.inventoryId === "PassiveJewels" && i.frameType === 3
+  );
+  //console.log("uniqueJewels: ", uniqueJewels);
+
+  //Normal Jewels
+  const prismaticJewels = nonUniqueJewels.filter(
+    (i) => i.typeLine === "Prismatic Jewel"
+  );
+  //console.log("prismaticJewels: ", prismaticJewels);
+
+  const cobaltJewels = nonUniqueJewels.filter(
+    (i) => i.typeLine === "Cobalt Jewel"
+  );
+  //console.log("cobaltJewels: ", cobaltJewels);
+
+  const crimsonJewels = nonUniqueJewels.filter(
+    (i) => i.typeLine === "Crimson Jewel"
+  );
+  //console.log("crimsonJewels: ", crimsonJewels);
+
+  const viridianJewels = nonUniqueJewels.filter(
+    (i) => i.typeLine === "Viridian Jewel"
+  );
+  //console.log("viridianJewels: ", viridianJewels);
 
   return (
     <>
-      <div className="flex flex-col">
-        <div className="flex flex-row">
+      <div className="flex flex-col items-center space-y-1">
+        <div className="flex flex-row space-x-1">
           {flasks.map((f) => (
             <>
               <div>
@@ -39,8 +88,9 @@ export default function SecondaryEquipmentDisplay({
             </>
           ))}
         </div>
-        <div className="flex flex-row">
-          {jewels.map((f) => (
+        <div className="flex flex-row space-x-1">
+          {/* Large Clusters */}
+          {largeClusterJewels.map((f) => (
             <>
               <div>
                 <ItemMouseOver item={f}>
@@ -55,6 +105,135 @@ export default function SecondaryEquipmentDisplay({
               </div>
             </>
           ))}
+          {/* Medium Clusters */}
+          {mediumClusterJewels.map((f) => (
+            <>
+              <div>
+                <ItemMouseOver item={f}>
+                  <Image
+                    loader={myLoader}
+                    width={40}
+                    height={60}
+                    src={f.icon!}
+                    alt={""}
+                  />
+                </ItemMouseOver>
+              </div>
+            </>
+          ))}
+          {/* Small Clusters */}
+          {smallClusterJewels.map((f) => (
+            <>
+              <div>
+                <ItemMouseOver item={f}>
+                  <Image
+                    loader={myLoader}
+                    width={40}
+                    height={60}
+                    src={f.icon!}
+                    alt={""}
+                  />
+                </ItemMouseOver>
+              </div>
+            </>
+          ))}
+          {/* Unique Jewels */}
+          {uniqueJewels.map((f) => (
+            <>
+              <div>
+                <ItemMouseOver item={f}>
+                  <Image
+                    loader={myLoader}
+                    width={40}
+                    height={60}
+                    src={f.icon!}
+                    alt={""}
+                  />
+                </ItemMouseOver>
+              </div>
+            </>
+          ))}
+          {/* Prismatic Jewels */}
+          {prismaticJewels.map((f) => (
+            <>
+              <div>
+                <ItemMouseOver item={f}>
+                  <Image
+                    loader={myLoader}
+                    width={40}
+                    height={60}
+                    src={f.icon!}
+                    alt={""}
+                  />
+                </ItemMouseOver>
+              </div>
+            </>
+          ))}
+          {/* Cobalt Jewels */}
+          {cobaltJewels.map((f) => (
+            <>
+              <div>
+                <ItemMouseOver item={f}>
+                  <Image
+                    loader={myLoader}
+                    width={40}
+                    height={60}
+                    src={f.icon!}
+                    alt={""}
+                  />
+                </ItemMouseOver>
+              </div>
+            </>
+          ))}
+          {/* Crimson  */}
+          {crimsonJewels.map((f) => (
+            <>
+              <div>
+                <ItemMouseOver item={f}>
+                  <Image
+                    loader={myLoader}
+                    width={40}
+                    height={60}
+                    src={f.icon!}
+                    alt={""}
+                  />
+                </ItemMouseOver>
+              </div>
+            </>
+          ))}
+          {/* Viridian */}
+          {viridianJewels.map((f) => (
+            <>
+              <div>
+                <ItemMouseOver item={f}>
+                  <Image
+                    loader={myLoader}
+                    width={40}
+                    height={60}
+                    src={f.icon!}
+                    alt={""}
+                  />
+                </ItemMouseOver>
+              </div>
+            </>
+          ))}
+          {/* Cobalt Jewels */}
+          {/* Small Jewels */}
+          {/* {jewels.map((f) => (
+            <>
+              <div>
+                <ItemMouseOver item={f}>
+                  <Image
+                    loader={myLoader}
+                    width={40}
+                    height={60}
+                    src={f.icon!}
+                    alt={""}
+                  />
+                </ItemMouseOver>
+              </div>
+            </>
+          ))} */}
         </div>
       </div>
     </>

--- a/src/components/secondary-equipment-display.tsx
+++ b/src/components/secondary-equipment-display.tsx
@@ -137,6 +137,8 @@ export default function SecondaryEquipmentDisplay({
               </div>
             </>
           ))}
+        </div>
+        <div className="flex flex-row space-x-1">
           {/* Unique Jewels */}
           {uniqueJewels.map((f) => (
             <>
@@ -153,6 +155,7 @@ export default function SecondaryEquipmentDisplay({
               </div>
             </>
           ))}
+
           {/* Prismatic Jewels */}
           {prismaticJewels.map((f) => (
             <>

--- a/src/components/secondary-equipment-display.tsx
+++ b/src/components/secondary-equipment-display.tsx
@@ -43,7 +43,12 @@ export default function SecondaryEquipmentDisplay({
 
   //Unique Jewels
   const uniqueJewels = items.filter(
-    (i) => i.inventoryId === "PassiveJewels" && i.frameType === 3
+    (i) =>
+      i.inventoryId === "PassiveJewels" &&
+      i.frameType === 3 &&
+      i.typeLine !== "Small Cluster Jewel" &&
+      i.typeLine !== "Medium Cluster Jewel" &&
+      i.typeLine !== "Large Cluster Jewel"
   );
   //console.log("uniqueJewels: ", uniqueJewels);
 

--- a/src/components/trees/skill-tree.tsx
+++ b/src/components/trees/skill-tree.tsx
@@ -85,15 +85,15 @@ export default function SkillTree({
         <LoadingIndicator />
       ) : (
         <>
-          <NodesTree
-            treeData={treeData}
-            selectedNodes={selectedNodes}
-            resetZoomEmitter={resetEmitter}
-          />
+          <div className="h-full ">
+            <NodesTree
+              treeData={treeData}
+              selectedNodes={selectedNodes}
+              resetZoomEmitter={resetEmitter}
+            />
+          </div>
           <StyledButton
-            className={
-              "w-32 flex flex-col items-center mx-auto text-center mt-4"
-            }
+            className={"w-32 flex flex-col items-center mx-auto"}
             text={"Reset View"}
             onClick={() => {
               resetEmitter?.dispatch();

--- a/src/components/trees/skill-tree.tsx
+++ b/src/components/trees/skill-tree.tsx
@@ -5,9 +5,13 @@ import { usePoeLeagueCtx } from "@contexts/league-context";
 import LoadingIndicator from "@components/loading-indicator";
 import NodesTree from "./nodes-tree/nodes-tree";
 import StyledButton from "@components/styled-button";
-import createResetZoomEventEmitter, { ResetEventEmitter } from "./nodes-tree/reset-zoom-event-emitter";
+import createResetZoomEventEmitter, {
+  ResetEventEmitter,
+} from "./nodes-tree/reset-zoom-event-emitter";
 
-const passiveSkillsLayoutQuery: TypedDocumentNode<{ passiveTree: PassiveTreeResponse }> = gql`
+const passiveSkillsLayoutQuery: TypedDocumentNode<{
+  passiveTree: PassiveTreeResponse;
+}> = gql`
   query PassiveTree($passiveTreeVersion: String!) {
     passiveTree(passiveTreeVersion: $passiveTreeVersion) {
       constants {
@@ -21,49 +25,51 @@ const passiveSkillsLayoutQuery: TypedDocumentNode<{ passiveTree: PassiveTreeResp
       nodeMap
       connectionMap
     }
-  }`;
+  }
+`;
 
 /**
  * Displays the Passives Skill tree for the given version.
- *   
+ *
  * If selectedNodes are passed it will highlight the nodes and
  * connections between them.
  */
-export default function SkillTree({ selectedNodes, version }: {
-  selectedNodes?: Array<number>,
-  version: string
+export default function SkillTree({
+  selectedNodes,
+  version,
+}: {
+  selectedNodes?: Array<number>;
+  version: string;
 }) {
   const { league } = usePoeLeagueCtx();
-  
+
   const [treeData, setTreeData] = useState<PassiveTreeResponse>();
 
   const [resetEmitter, setResetEmitter] = useState<ResetEventEmitter>();
-  
-  const { refetch, loading } = useQuery(
-    passiveSkillsLayoutQuery,
-    {
-        skip: true,
-        variables: { 
-        passiveTreeVersion: version,
-        league: league
-      },
-      onCompleted({ passiveTree }) {
-        setTreeData(passiveTree);
-        if (passiveTree) {
-          localStorage.setItem(
-            `${version}_passive_tree_data`,
-            JSON.stringify(passiveTree)
-          );
-        }
+
+  const { refetch, loading } = useQuery(passiveSkillsLayoutQuery, {
+    skip: true,
+    variables: {
+      passiveTreeVersion: version,
+      league: league,
+    },
+    onCompleted({ passiveTree }) {
+      setTreeData(passiveTree);
+      if (passiveTree) {
+        localStorage.setItem(
+          `${version}_passive_tree_data`,
+          JSON.stringify(passiveTree)
+        );
       }
+    },
   });
-  
-  useEffect(()=>{
-    setResetEmitter(createResetZoomEventEmitter());
-  },[])
 
   useEffect(() => {
-    if (typeof window !== 'undefined' && !treeData) {
+    setResetEmitter(createResetZoomEventEmitter());
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && !treeData) {
       const localData = localStorage.getItem(`${version}_passive_tree_data`);
       if (localData) {
         setTreeData(JSON.parse(localData));
@@ -71,17 +77,30 @@ export default function SkillTree({ selectedNodes, version }: {
         refetch();
       }
     }
-  }, [treeData, refetch, version]);    
-  
+  }, [treeData, refetch, version]);
+
   return (
-    <>{
-      loading || !treeData?
-        <LoadingIndicator/> 
-        :
+    <>
+      {loading || !treeData ? (
+        <LoadingIndicator />
+      ) : (
         <>
-          <StyledButton className={"w-32"} text={"Reset View"} onClick={()=>{resetEmitter?.dispatch()}}/>
-          <NodesTree treeData={treeData} selectedNodes={selectedNodes} resetZoomEmitter={resetEmitter}/>
+          <NodesTree
+            treeData={treeData}
+            selectedNodes={selectedNodes}
+            resetZoomEmitter={resetEmitter}
+          />
+          <StyledButton
+            className={
+              "w-32 flex flex-col items-center mx-auto text-center mt-4"
+            }
+            text={"Reset View"}
+            onClick={() => {
+              resetEmitter?.dispatch();
+            }}
+          />
         </>
-    }</>
+      )}
+    </>
   );
 }

--- a/src/pages/poe/character/[characterId].tsx
+++ b/src/pages/poe/character/[characterId].tsx
@@ -188,6 +188,7 @@ export default function Character({ characterSnapshot }) {
           />
         </Head>
         <div className="flex flex-col gap-2 lg:grid lg:grid-cols-12 lg:grid-rows-[200px, 200px, 200px, 200px] ">
+          {/* Equipment */}
           <div className="flex lg:grid lg:col-start-4 lg:col-end-9 lg:row-start-1 lg:row-end-2  w-full h-full bg-primary ">
             <div className="flex flex-col space-y-1 items-center bg-surface-secondary p-3">
               <EquipmentDisplay
@@ -198,6 +199,7 @@ export default function Character({ characterSnapshot }) {
               />
             </div>
           </div>
+          {/* Stats */}
           <div className="grid col-start-1 col-end-4 row-start-1 row-end-2 font-semibold">
             <StyledCard>
               <div className="grid grid-cols-2 w-full h-full">
@@ -304,6 +306,7 @@ export default function Character({ characterSnapshot }) {
             </StyledCard>
           </div>
 
+          {/* Atlas */}
           <div className="flex lg:grid lg:col-start-9 lg:col-end-13 lg:row-start-1 lg:row-end-2">
             <StyledCard title={"Passive Tree"}>
               <SkillTree
@@ -314,6 +317,7 @@ export default function Character({ characterSnapshot }) {
               />
             </StyledCard>
           </div>
+          {/* Graphs & Snapshots */}
           <div className="grid col-start-4 col-end-9 row-start-2 row-end-3">
             <StyledCard title="Snapshots" className="flex-1">
               <div className="flex flex-col space-y-2">

--- a/src/pages/poe/character/[characterId].tsx
+++ b/src/pages/poe/character/[characterId].tsx
@@ -18,6 +18,7 @@ import CharacterLevelChart from "@components/character-level-chart";
 import Head from "next/head";
 import client from "poe-stack-apollo-client";
 import { GeneralUtils } from "@utils/general-util";
+import Image from "next/image";
 
 const snapshotQuery = gql`
   query SingleCharacterCharacterSnapshotsSearch($snapshotId: String!) {
@@ -169,6 +170,7 @@ export default function Character({ characterSnapshot }) {
   Res ${currentSnapshot?.characterSnapshotPobStats?.fireResist}/${currentSnapshot?.characterSnapshotPobStats?.coldResist}/${currentSnapshot?.characterSnapshotPobStats?.lightningResist}/${currentSnapshot?.characterSnapshotPobStats?.chaosResist}
   DPS ${currentSnapshot?.characterSnapshotPobStats?.totalDpsWithIgnite}`;
 
+  console.log("currentSnapshotchar: ", currentSnapshot);
   return (
     <>
       <div className="flex flex-col my-4 space-y-2 md:mx-4 lg:mx-20">
@@ -196,7 +198,7 @@ export default function Character({ characterSnapshot }) {
               />
             </div>
           </div>
-          <div className="grid col-start-1 col-end-4 row-start-1 row-end-2">
+          <div className="grid col-start-1 col-end-4 row-start-1 row-end-2 font-semibold">
             <StyledCard>
               <div className="grid grid-cols-2 w-full h-full">
                 <div className="col-start-1 col-end-2  ">
@@ -204,16 +206,91 @@ export default function Character({ characterSnapshot }) {
                     pobStats={currentSnapshot?.characterSnapshotPobStats}
                   />
                 </div>
-                <div className="col-start-2 col-end-3">
-                  <p>other column</p>
+                <div className="col-start-2 col-end-3 pl-4">
+                  <div className="flex flex-row mt-4 justify-center">
+                    <Image
+                      src={`/assets/poe/classes/${currentSnapshot?.characterClass}.png`}
+                      alt={currentSnapshot!.characterClass}
+                      width={120}
+                      height={30}
+                    />
+                  </div>
+                  <div className="grid grid-cols-1 gap-x-3 w-full h-full mt-4 ">
+                    <div>
+                      <div className="flex flex-row hover:bg-color-primary-variant ">
+                        <h3>Name:</h3>
+                        <h5 className=" mx-2  text-right w-full">
+                          {currentSnapshot?.poeCharacter?.name}
+                        </h5>
+                      </div>
+                      <div className="flex flex-row hover:bg-color-primary-variant ">
+                        <h3>League:</h3>{" "}
+                        <h5 className=" mx-2 text-right w-full">
+                          {currentSnapshot?.league}
+                        </h5>
+                      </div>
+                      <div className="flex flex-row hover:bg-color-primary-variant ">
+                        <h3>Level:</h3>{" "}
+                        <h5 className=" mx-2 text-right w-full">
+                          {currentSnapshot?.level}
+                        </h5>
+                      </div>
+                      <div className="flex flex-row hover:bg-color-primary-variant">
+                        <h3>Class:</h3>{" "}
+                        <h5 className=" mx-2 text-right w-full">
+                          {currentSnapshot?.characterClass}
+                        </h5>
+                      </div>
+                      <div className="flex flex-row hover:bg-color-primary-variant">
+                        <h3>Skill:</h3>{" "}
+                        <h5 className=" mx-2 text-right w-full">
+                          {GeneralUtils.capitalize(
+                            currentSnapshot?.mainSkillKey
+                          )}
+                        </h5>
+                      </div>
+                      <div className="flex flex-row hover:bg-color-primary-variant">
+                        <h3>DPS:</h3>{" "}
+                        <h5 className=" mx-2 text-right w-full">
+                          {
+                            currentSnapshot?.characterSnapshotPobStats
+                              ?.totalDpsWithIgnite
+                          }
+                        </h5>
+                      </div>
+                      <h2 className="text-center mt-8">Choices</h2>
+                      <div className="flex flex-row hover:bg-color-primary-variant ">
+                        <h3>Bandit:</h3>
+                        <h5 className=" mx-4  text-right w-full">
+                          {
+                            currentSnapshot?.characterPassivesSnapshot
+                              ?.banditChoice
+                          }
+                        </h5>
+                      </div>
+                      <div className="flex flex-row hover:bg-color-primary-variant ">
+                        <h3>Major:</h3>{" "}
+                        <h5 className=" mx-4  text-right w-full">
+                          {currentSnapshot?.characterPassivesSnapshot?.pantheonMajor?.replace(
+                            /([a-z])([A-Z])/g,
+                            "$1 $2"
+                          )}
+                        </h5>
+                      </div>
+                      <div className="flex flex-row hover:bg-color-primary-variant ">
+                        <h3>Minor:</h3>{" "}
+                        <h5 className=" mx-4  text-right w-full">
+                          {currentSnapshot?.characterPassivesSnapshot?.pantheonMinor?.replace(
+                            /([a-z])([A-Z])/g,
+                            "$1 $2"
+                          )}
+                        </h5>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
-            </StyledCard>
-          </div>
-
-          <div className="flex lg:grid lg:col-start-9 lg:col-end-13 lg:row-start-1 lg:row-end-2">
-            <StyledCard title={"Passive Tree"}>
-              <div className="flex flex-row w-full justify-center pb-4 ">
+              <div className="flex flex-row w-full justify-center mt-2 ">
                 <StyledButton
                   text={"Copy POB Code"}
                   onClick={() => {
@@ -224,6 +301,11 @@ export default function Character({ characterSnapshot }) {
                   }}
                 />
               </div>
+            </StyledCard>
+          </div>
+
+          <div className="flex lg:grid lg:col-start-9 lg:col-end-13 lg:row-start-1 lg:row-end-2">
+            <StyledCard title={"Passive Tree"}>
               <SkillTree
                 version={"3.20"}
                 selectedNodes={
@@ -303,40 +385,6 @@ export default function Character({ characterSnapshot }) {
             </StyledCard>
           </div>
         </div>
-      </div>
-      <div className="flex flex-row space-x-2">
-        <StyledCard title="Character" className="flex-1">
-          <div>
-            <div>{currentSnapshot?.league}</div>
-            <div>{currentSnapshot?.poeCharacter?.name}</div>
-            <div>
-              Level {currentSnapshot?.level} {currentSnapshot?.characterClass}
-            </div>
-            <div>
-              Main Skill{" "}
-              {GeneralUtils.capitalize(currentSnapshot?.mainSkillKey)}
-            </div>
-            <div>
-              DPS{" "}
-              {currentSnapshot?.characterSnapshotPobStats?.totalDpsWithIgnite}
-            </div>
-          </div>
-        </StyledCard>
-        <StyledCard title={"Info"} className="flex-1">
-          <div>
-            <div>
-              Bandit: {currentSnapshot?.characterPassivesSnapshot?.banditChoice}
-            </div>
-            <div>
-              Pantheon Major:{" "}
-              {currentSnapshot?.characterPassivesSnapshot?.pantheonMajor}
-            </div>
-            <div>
-              Pantheon Minor:{" "}
-              {currentSnapshot?.characterPassivesSnapshot?.pantheonMinor}
-            </div>
-          </div>
-        </StyledCard>
       </div>
     </>
   );

--- a/src/pages/poe/character/[characterId].tsx
+++ b/src/pages/poe/character/[characterId].tsx
@@ -188,7 +188,7 @@ export default function Character({ characterSnapshot }) {
         <div className="flex space-x-2 ">
           <div>
             <StyledCard title="Equipment" className="min-w-[450px]">
-              <div className="flex flex-col space-y-2">
+              <div className="flex flex-col space-y-1 items-center">
                 <EquipmentDisplay
                   items={currentSnapshot?.characterSnapshotItems!}
                 />

--- a/src/pages/poe/character/[characterId].tsx
+++ b/src/pages/poe/character/[characterId].tsx
@@ -185,7 +185,7 @@ export default function Character({ characterSnapshot }) {
             content={`/assets/poe/classes/${currentSnapshot?.characterClass}.png`}
           />
         </Head>
-        <div className="flex space-x-2 ">
+        <div className="grid">
           <div>
             <StyledCard title="Equipment" className="min-w-[450px]">
               <div className="flex flex-col space-y-1 items-center">

--- a/src/pages/poe/character/[characterId].tsx
+++ b/src/pages/poe/character/[characterId].tsx
@@ -185,21 +185,54 @@ export default function Character({ characterSnapshot }) {
             content={`/assets/poe/classes/${currentSnapshot?.characterClass}.png`}
           />
         </Head>
-        <div className="grid">
-          <div>
-            <StyledCard title="Equipment" className="min-w-[450px]">
-              <div className="flex flex-col space-y-1 items-center">
-                <EquipmentDisplay
-                  items={currentSnapshot?.characterSnapshotItems!}
-                />
-                <SecondaryEquipmentDisplay
-                  items={currentSnapshot?.characterSnapshotItems!}
-                />
+        <div className="flex flex-col gap-2 lg:grid lg:grid-cols-12 lg:grid-rows-[200px, 200px, 200px, 200px] ">
+          <div className="flex lg:grid lg:col-start-4 lg:col-end-9 lg:row-start-1 lg:row-end-2  w-full h-full bg-primary ">
+            <div className="flex flex-col space-y-1 items-center bg-surface-secondary p-3">
+              <EquipmentDisplay
+                items={currentSnapshot?.characterSnapshotItems!}
+              />
+              <SecondaryEquipmentDisplay
+                items={currentSnapshot?.characterSnapshotItems!}
+              />
+            </div>
+          </div>
+          <div className="grid col-start-1 col-end-4 row-start-1 row-end-2">
+            <StyledCard>
+              <div className="grid grid-cols-2 w-full h-full">
+                <div className="col-start-1 col-end-2  ">
+                  <CharacterStatsDisplay
+                    pobStats={currentSnapshot?.characterSnapshotPobStats}
+                  />
+                </div>
+                <div className="col-start-2 col-end-3">
+                  <p>other column</p>
+                </div>
               </div>
             </StyledCard>
           </div>
 
-          <div className="flex flex-col flex-1 space-y-2 ">
+          <div className="flex lg:grid lg:col-start-9 lg:col-end-13 lg:row-start-1 lg:row-end-2">
+            <StyledCard title={"Passive Tree"}>
+              <div className="flex flex-row w-full justify-center pb-4 ">
+                <StyledButton
+                  text={"Copy POB Code"}
+                  onClick={() => {
+                    navigator.clipboard.writeText(
+                      currentSnapshot?.characterSnapshotPobStats?.pobCode ??
+                        "not found"
+                    );
+                  }}
+                />
+              </div>
+              <SkillTree
+                version={"3.20"}
+                selectedNodes={
+                  currentSnapshot?.characterPassivesSnapshot?.hashes
+                }
+              />
+            </StyledCard>
+          </div>
+          <div className="grid col-start-4 col-end-9 row-start-2 row-end-3">
             <StyledCard title="Snapshots" className="flex-1">
               <div className="flex flex-col space-y-2">
                 <StyledSelect2
@@ -215,6 +248,7 @@ export default function Character({ characterSnapshot }) {
                     });
                   }}
                 />
+
                 <div className="flex flex-row w-full space-x-2">
                   <StyledButton
                     className="flex-1"
@@ -269,54 +303,39 @@ export default function Character({ characterSnapshot }) {
             </StyledCard>
           </div>
         </div>
-        <div className="flex flex-row space-x-2">
-          <StyledCard title="Character" className="flex-1">
+      </div>
+      <div className="flex flex-row space-x-2">
+        <StyledCard title="Character" className="flex-1">
+          <div>
+            <div>{currentSnapshot?.league}</div>
+            <div>{currentSnapshot?.poeCharacter?.name}</div>
             <div>
-              <div>{currentSnapshot?.league}</div>
-              <div>{currentSnapshot?.poeCharacter?.name}</div>
-              <div>
-                Level {currentSnapshot?.level} {currentSnapshot?.characterClass}
-              </div>
-              <div>
-                Main Skill{" "}
-                {GeneralUtils.capitalize(currentSnapshot?.mainSkillKey)}
-              </div>
-              <div>
-                DPS{" "}
-                {currentSnapshot?.characterSnapshotPobStats?.totalDpsWithIgnite}
-              </div>
+              Level {currentSnapshot?.level} {currentSnapshot?.characterClass}
             </div>
-          </StyledCard>
-          <StyledCard title={"Info"} className="flex-1">
             <div>
-              <div>
-                Bandit:{" "}
-                {currentSnapshot?.characterPassivesSnapshot?.banditChoice}
-              </div>
-              <div>
-                Pantheon Major:{" "}
-                {currentSnapshot?.characterPassivesSnapshot?.pantheonMajor}
-              </div>
-              <div>
-                Pantheon Minor:{" "}
-                {currentSnapshot?.characterPassivesSnapshot?.pantheonMinor}
-              </div>
+              Main Skill{" "}
+              {GeneralUtils.capitalize(currentSnapshot?.mainSkillKey)}
             </div>
-          </StyledCard>
-        </div>
-        <div className="flex flex-row space-x-2">
-          <StyledCard title={"Pob Stats"} className="flex-1">
-            <CharacterStatsDisplay
-              pobStats={currentSnapshot?.characterSnapshotPobStats}
-            />
-          </StyledCard>
-        </div>
-
-        <StyledCard title={"Passive Tree"}>
-          <SkillTree
-            version={"3.20"}
-            selectedNodes={currentSnapshot?.characterPassivesSnapshot?.hashes}
-          />
+            <div>
+              DPS{" "}
+              {currentSnapshot?.characterSnapshotPobStats?.totalDpsWithIgnite}
+            </div>
+          </div>
+        </StyledCard>
+        <StyledCard title={"Info"} className="flex-1">
+          <div>
+            <div>
+              Bandit: {currentSnapshot?.characterPassivesSnapshot?.banditChoice}
+            </div>
+            <div>
+              Pantheon Major:{" "}
+              {currentSnapshot?.characterPassivesSnapshot?.pantheonMajor}
+            </div>
+            <div>
+              Pantheon Minor:{" "}
+              {currentSnapshot?.characterPassivesSnapshot?.pantheonMinor}
+            </div>
+          </div>
         </StyledCard>
       </div>
     </>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -19,6 +19,11 @@
     --color-secondary-variant: #5b5f62;
     --color-accent: #faa307;
     --color-accent-variant: #bb7526;
+    /* Item Colors */
+    --color-normal: #c8c8c8;
+    --color-magic: #8888ff;
+    --color-rare: #ffff77;
+    --color-unique: #af6025;
     /* Surfaces - Backgrounds/Components */
     --color-background-primary: #121212;
     --color-background-primary-variant: #252525;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -63,17 +63,9 @@ module.exports = {
         },
       },
       backgroundImage: {
-        characterLadder:
-          'url("/images/landingpage/landingPage_Char_Ladder_001.png")',
-        stash: 'url("/images/landingpage/landingPage_Stash_001.png")',
-        characterProfile:
-          'url("/images/landingpage/landingPage_User_Characters_001.png")',
-        economyMageblood:
-          'url("/images/landingpage/landingPage_Economy_001.png")',
-        economyEssences:
-          'url("/images/landingpage/landingPage_Economy_002.png")',
         kekw: 'url("/KEKW.png")',
       },
+
       // colors: {
       //   "theme-color-0": "#060F2F",
       //   "theme-color-1": "#1B2240",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,6 +34,10 @@ module.exports = {
           accent: "var(--color-accent)",
           "accent-variant": "var(--color-accent-variant)",
           red: "var(--color-red)",
+          normal: "var(--color-normal)",
+          magic: "var(--color-magic)",
+          rare: "var(--color-rare)",
+          unique: "var(--color-unique)",
         },
         // surfaces
         surface: {
@@ -52,6 +56,10 @@ module.exports = {
           secondary: "var(--color-background-secondary)",
           "secondary-variant": "var(--color-background-secondary-variant)",
           accent: "var(--color-accent)",
+          normal: "var(--color-normal)",
+          magic: "var(--color-magic)",
+          rare: "var(--color-rare)",
+          unique: "var(--color-unique)",
         },
       },
       backgroundImage: {


### PR DESCRIPTION
Redesign Layout Character Page:

12 column & 2 Row setup: 

1st Row:
Middle (5 Columns) -- Become first section on mobile
- Equipment w/ links + sockets including empty sockets now shown
- Support gems are circular
- Active skill gems are diamond shape
- Setup on a grid so it should ideally scale and morph to mobile.

Left Side (3 Columns) -- Becomes 2nd section on Mobile
- Character Stats, important stats color coded. 
- Copy POB button

Right (3 Columns) -- Becomes 3rd section on Mobile
- Atlas Tree

2nd Row:
Middle
- Leveling Graph

Left and Right side are available for future features.

Possible ideas:
1) Another Graph but cost/value of equipment. So players can track over the course of a league the amount of currency they've invested in uniques/jewels/clusters for a character
2) Another viewing of links similar to how PoeNinja has
3) A quick finder of builds with similar items, and atlas tree nodes, but maybe favor for either different ascendancies so people can see what other builds they can do with their current equipment/nodes.

