### PR TITLE
faq icon fix

### DIFF
--- a/src/pages/poe/faq.tsx
+++ b/src/pages/poe/faq.tsx
@@ -128,15 +128,15 @@ export default function FAQPage() {
                               </span>
                               <span className="flex items-center ml-6 h-7">
                                 {open ? (
-                                  <PlusSmallIcon
-                                    className="w-6 h-6"
-                                    aria-hidden="true"
-                                  />
-                                ) : (
                                   <MinusSmallIcon
-                                    className="w-6 h-6"
-                                    aria-hidden="true"
-                                  />
+                                  className="w-6 h-6"
+                                  aria-hidden="true"
+                                />
+                                ) : (
+                                  <PlusSmallIcon
+                                  className="w-6 h-6"
+                                  aria-hidden="true"
+                                />
                                 )}
                               </span>
                             </Disclosure.Button>

--- a/src/pages/poe/faq.tsx
+++ b/src/pages/poe/faq.tsx
@@ -129,14 +129,14 @@ export default function FAQPage() {
                               <span className="flex items-center ml-6 h-7">
                                 {open ? (
                                   <MinusSmallIcon
-                                  className="w-6 h-6"
-                                  aria-hidden="true"
-                                />
+                                    className="w-6 h-6"
+                                    aria-hidden="true"
+                                  />
                                 ) : (
                                   <PlusSmallIcon
-                                  className="w-6 h-6"
-                                  aria-hidden="true"
-                                />
+                                    className="w-6 h-6"
+                                    aria-hidden="true"
+                                  />
                                 )}
                               </span>
                             </Disclosure.Button>


### PR DESCRIPTION
the faq icons are swapped on the live site, showing a minus when the faq is closed and a plus when it is open, presumably we want the icon to match the action that will happen when clicked, and not the current state of the faq (bit weird to click a minus symbol that opens something), so we swap them