### PR TITLE
Force divine orbs to display as chaos value in economy table

### DIFF
--- a/src/components/currency-value-display.tsx
+++ b/src/components/currency-value-display.tsx
@@ -20,10 +20,12 @@ export default function CurrencyValueDisplay({
   pValue,
   onClick = null,
   league,
+  forceChaosDisplay,
 }: {
   pValue: number;
   league: string | null | undefined;
   onClick?: null | ((n) => void);
+  forceChaosDisplay?: boolean;
 }) {
   const [display, setDisplay] = useState<string>("");
   const [icon, setIcon] = useState<string>(CHAOS_ICON);
@@ -64,7 +66,11 @@ export default function CurrencyValueDisplay({
     let newDisplay = "" + round(absValue);
     if (league?.toLowerCase()?.includes("ruthless")) {
       setIcon(ALCH_ICON);
-    } else if (chaosRates?.div && absValue >= chaosRates?.div) {
+    } else if (
+      chaosRates?.div &&
+      absValue >= chaosRates?.div &&
+      !forceChaosDisplay
+    ) {
       newDisplay = "" + round(absValue / chaosRates?.div);
       setIcon(DIV_ICON);
     } else {

--- a/src/pages/poe/economy/[league].tsx
+++ b/src/pages/poe/economy/[league].tsx
@@ -224,6 +224,11 @@ export default function Economy() {
                                   ?.value ?? 0
                               }
                               league={league}
+                              forceChaosDisplay={
+                                GeneralUtils.itemGroupToDisplayName(
+                                  groupSeries.itemGroup!
+                                ) === "Divine Orb"
+                              }
                             />
                           </>
                         );


### PR DESCRIPTION
Addresses https://github.com/PoeStack/poestack-next/issues/59

Fairly easily to expand in the future if necessary by using a set of the items you always want to force to chaos values instead of just hardchecking "Divine Orb" only.